### PR TITLE
Fix import issue when a shorter base path matches before a shorter one

### DIFF
--- a/kibot/mcpyrate/coreutils.py
+++ b/kibot/mcpyrate/coreutils.py
@@ -56,7 +56,9 @@ def match_syspath(filename):
     If `filename` is not under any directory in `sys.path`, raises `ValueError`.
     """
     absolute_filename = str(pathlib.Path(filename).expanduser().resolve())
-    for root_path in sys.path:
+    # We sort the paths in reverse order of length so a longer path matches
+    # before a shorter one.
+    for root_path in sorted(sys.path, key=len, reverse=True):
         root_path = pathlib.Path(root_path).expanduser().resolve()
         if absolute_filename.startswith(str(root_path)):
             return root_path


### PR DESCRIPTION
There is an error that prevents kibot from starting when `sys.path` contains a parent of another path (issue #29).

For example, if `sys.path` contains:

```
/home/user/.local/
/home/user/.local/lib/python3.8/site-packages/
```

The path resolution algorithm will find the first one first and then fail to find the package there (which makes sense, because that's not a Python package directory). This PR sorts the path names by length, so a longer path will always match before a shorter one.