### PR TITLE
Added kicad-git-filters installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ FROM setsoft/kicad_auto:latest
 LABEL AUTHOR Salvador E. Tropea <set@ieee.org>
 LABEL Description="export various files from KiCad projects"
 
+RUN     apt-get update  && \
+	apt-get -y install make wget curl && \
+	curl -s https://api.github.com/repos/INTI-CMNB/kicad-git-filters/releases/latest | grep "browser_download_url.*deb" | cut -d : -f 2,3 | tr -d \" | wget -i - && \
+	apt -y install --no-install-recommends ./*.deb && \
+	apt-get -y remove curl wget && \
+	apt-get -y autoremove && \
+	rm /*.deb && \
+	rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
This is a fix for the following error when executing as a github action:
`/entrypoint.sh: line 144: /usr/bin/kicad-git-filters.py: No such file or directory`

This was reported in #37