### PR TITLE
fix: Part containing more then 9 units (2 digits present). Start line…

### DIFF
--- a/kibot/kicad/v5_sch.py
+++ b/kibot/kicad/v5_sch.py
@@ -1010,11 +1010,11 @@ class SchematicComponent(object):
         # Redundant pos
         if not line.startswith('\t'+str(comp.unit)):
             raise SchFileError('Missing component redundant position', line, f)
-        res = _split_space(line[2:])
-        if len(res) != 2:
+        res = _split_space(line[1:])
+        if len(res) != 3:
             raise SchFileError('Malformed component redundant position', line, f)
-        xr = int(res[0])
-        yr = int(res[1])
+        xr = int(res[1])
+        yr = int(res[2])
         if comp.x != xr or comp.y != yr:
             logger.warning(W_INCPOS + 'Inconsistent position for component {} ({},{} vs {},{})'.
                            format(comp.f_ref, comp.x, comp.y, xr, yr))


### PR DESCRIPTION
Parsing schematic file cause an error when the Part has more then 9 units (e.g. signal connector split into several units to fit to hierarchical schematic structure) and current unit to be parsed has 2 digits.
Example, Unit 12:

```
F 3 "" H 8300 2750 50  0001 C CNN
	12   6600 3250
	-1   0    0    -1 
```