### PR TITLE
be more tolerant when parsing libraries

### DIFF
--- a/kibot/kicad/v5_sch.py
+++ b/kibot/kicad/v5_sch.py
@@ -69,7 +69,7 @@ class LibLineReader(LineReader):
     def get_line(self):
         res = self.f.readline()
         while res and res[0] == '#':
-            if res.startswith('#End Library'):
+            if res.startswith('#End Library') or res.startswith('# End Library'):
                 return res.rstrip()
             self.line += 1
             res = self.f.readline()
@@ -635,7 +635,7 @@ class SymLib(object):
             if not line.startswith('EESchema-LIBRARY'):
                 raise SchLibError('Missing library signature', line, f)
             line = f.get_line()
-            while not line.startswith('#End Library'):
+            while not (line.startswith('#End Library') or line.startswith('# End Library')):
                 if line.startswith('DEF'):
                     o = LibComponent(line, f, file)
                     if o.name:


### PR DESCRIPTION
Hi,


I just stumbled across KiBot and I have to admit that I am really impressed by the amount of work you've put into the project. And it has some really good (and extensive(!) documentation), which is usually something that a lot of open source projects are lacking. Many thanks for that! :)

While playing a bit with KiBot, I stumbled across a (what I believe to be) bug. The issue can be triggered by some libraries from snapeda.com (e.g this one: https://www.snapeda.com/parts/TS3A27518EPWR/Texas%20Instruments/view-part/). 

I've seen that KiBot assumes that the *.lib ends with a `#End Library` token. But (some) libs from SnapEDA use the token `# End Library` (with a space between `#` and `E`), causing KiBot to fail with:

```
ERROR:Trace stack: (kibot.kibot.error - error.py:33)
  File "/home/bernhard/.local/lib/python3.7/site-packages/kibot/kiplot.py", line 197, in load_any_sch
    sch.load_libs(file)
  File "/home/bernhard/.local/lib/python3.7/site-packages/kibot/kicad/v5_sch.py", line 1541, in load_libs
    o.load(v, k, self.comps_data)
  File "/home/bernhard/.local/lib/python3.7/site-packages/kibot/kicad/v5_sch.py", line 652, in load
    line = f.get_line()
  File "/home/bernhard/.local/lib/python3.7/site-packages/kibot/kicad/v5_sch.py", line 78, in get_line
    raise SchLibError('Unexpected end of file', '', self)
ERROR:At line 46 of `/media/bernhard/Data/Projects/sdcard-switcher/hardware/sdcard-switcher/libs/TS3A27518EPWR/TS3A27518EPWR.lib`: Unexpected end of file (kibot.kibot.kiplot - kiplot.py:202)
```

This commit should fix the issue. 

Unfortunately, I haven't found any documentation regarding the library format...so I am not sure whether an arbitrary number of spaces between `#` and `End Library` are allowed, or if it's just at max one. In order to play it safe, I went with one space.

Let me know in case I've missed something.