### PR TITLE
Added invert_bottom and side selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Currently the only type available is `generic`.
     - `negative_bottom`: [boolean=true] Rotation for bottom components is computed via subtraction as `(component rot - angle)`.
     - `invert_bottom`: [boolean=false] Rotation for bottom components is negated.
     - `rotations`: [list(list(string))] A list of pairs regular expression/rotation.
-                   Components matching the regular expression will be rotated the indicated angle.
+                   Components matching the regular expression will be rotated the indicated angle. Special names `_top` and `_bottom` will match all components on that side of the board.
 - subparts: Subparts
         This filter implements the KiCost subparts mechanism.
   * Valid keys:
@@ -2184,7 +2184,7 @@ The filter supports the following options:
 - `extend`: [boolean=true] Extends the internal list of rotations with the one provided. Otherwise just use the provided list.
 - `negative_bottom`: [boolean=true] Rotation for bottom components is computed via subtraction as `(component rot - angle)`. Note that this should be coherent with the `bottom_negative_x` of the position output.
 - `invert_bottom`: [boolean=false] Rotation for bottom components is negated, resulting in either : `(- component rot - angle)` or when combined with `negative_bottom`, `(angle - component rot)`.
-- `rotations`: [list(list(string))] A list of pairs regular expression/rotation. Components matching the regular expression will be rotated the indicated angle.
+- `rotations`: [list(list(string))] A list of pairs regular expression/rotation. Components matching the regular expression will be rotated the indicated angle. Special names `_top` and `_bottom` will match all components on that side of the board.
 
 In order to add a new rotation or just change an existing one you just need to use the `rotations` option.
 As an example: the internal list of rotations rotates QFN packages by 270 degrees, no suppose you want to rotate them just 90 degrees.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,8 @@ Currently the only type available is `generic`.
     - `extend`: [boolean=true] Extends the internal list of rotations with the one provided.
                 Otherwise just use the provided list.
     - `name`: [string=''] Used to identify this particular filter definition.
-    - `negative_bottom`: [boolean=true] Rotation for bottom components is computed substracting.
+    - `negative_bottom`: [boolean=true] Rotation for bottom components is computed via subtraction as `(component rot - angle)`.
+    - `invert_bottom`: [boolean=false] Rotation for bottom components is negated.
     - `rotations`: [list(list(string))] A list of pairs regular expression/rotation.
                    Components matching the regular expression will be rotated the indicated angle.
 - subparts: Subparts
@@ -2181,7 +2182,8 @@ Using it, instead of the internal filter named `_rot_footprint`, is the same her
 The filter supports the following options:
 
 - `extend`: [boolean=true] Extends the internal list of rotations with the one provided. Otherwise just use the provided list.
-- `negative_bottom`: [boolean=true] Rotation for bottom components is computed substracting. Note that this should be coherent with the `bottom_negative_x` of the position output.
+- `negative_bottom`: [boolean=true] Rotation for bottom components is computed via subtraction as `(component rot - angle)`. Note that this should be coherent with the `bottom_negative_x` of the position output.
+- `invert_bottom`: [boolean=false] Rotation for bottom components is negated, resulting in either : `(- component rot - angle)` or when combined with `negative_bottom`, `(angle - component rot)`.
 - `rotations`: [list(list(string))] A list of pairs regular expression/rotation. Components matching the regular expression will be rotated the indicated angle.
 
 In order to add a new rotation or just change an existing one you just need to use the `rotations` option.

--- a/docs/README.in
+++ b/docs/README.in
@@ -1177,7 +1177,7 @@ The filter supports the following options:
 - `extend`: [boolean=true] Extends the internal list of rotations with the one provided. Otherwise just use the provided list.
 - `negative_bottom`: [boolean=true] Rotation for bottom components is computed via substracting. Note that this should be coherent with the `bottom_negative_x` of the position output.
 - `invert_bottom`: [boolean=false] Rotation for bottom components is negated, resulting in either : `(- component rot - angle)` or when combined with `negative_bottom`, `(angle - component rot)`
-- `rotations`: [list(list(string))] A list of pairs regular expression/rotation. Components matching the regular expression will be rotated the indicated angle.
+- `rotations`: [list(list(string))] A list of pairs regular expression/rotation. Components matching the regular expression will be rotated the indicated angle. Special names `_top` and `_bottom` will match all components on that side of the board.
 
 In order to add a new rotation or just change an existing one you just need to use the `rotations` option.
 As an example: the internal list of rotations rotates QFN packages by 270 degrees, no suppose you want to rotate them just 90 degrees.

--- a/docs/README.in
+++ b/docs/README.in
@@ -1175,7 +1175,8 @@ Using it, instead of the internal filter named `_rot_footprint`, is the same her
 The filter supports the following options:
 
 - `extend`: [boolean=true] Extends the internal list of rotations with the one provided. Otherwise just use the provided list.
-- `negative_bottom`: [boolean=true] Rotation for bottom components is computed substracting. Note that this should be coherent with the `bottom_negative_x` of the position output.
+- `negative_bottom`: [boolean=true] Rotation for bottom components is computed via substracting. Note that this should be coherent with the `bottom_negative_x` of the position output.
+- `invert_bottom`: [boolean=false] Rotation for bottom components is negated, resulting in either : `(- component rot - angle)` or when combined with `negative_bottom`, `(angle - component rot)`
 - `rotations`: [list(list(string))] A list of pairs regular expression/rotation. Components matching the regular expression will be rotated the indicated angle.
 
 In order to add a new rotation or just change an existing one you just need to use the `rotations` option.

--- a/kibot/fil_rot_footprint.py
+++ b/kibot/fil_rot_footprint.py
@@ -92,7 +92,8 @@ class Rot_Footprint(BaseFilter):  # noqa: F821
     def filter(self, comp):
         """ Apply the rotation """
         for regex, angle in self._rot:
-            if regex.search(comp.footprint):
+            side = "_bottom" if comp.bottom else "_top"
+            if regex.search(comp.footprint) or regex.search(side):
                 old_angle = comp.footprint_rot
                 if self.negative_bottom and comp.bottom:
                     comp.footprint_rot -= angle

--- a/kibot/fil_rot_footprint.py
+++ b/kibot/fil_rot_footprint.py
@@ -93,7 +93,8 @@ class Rot_Footprint(BaseFilter):  # noqa: F821
         """ Apply the rotation """
         for regex, angle in self._rot:
             side = "_bottom" if comp.bottom else "_top"
-            if regex.search(comp.footprint) or regex.search(side):
+            match_string = comp.footprint + side
+            if regex.search(match_string):
                 old_angle = comp.footprint_rot
                 if self.negative_bottom and comp.bottom:
                     comp.footprint_rot -= angle

--- a/kibot/fil_rot_footprint.py
+++ b/kibot/fil_rot_footprint.py
@@ -61,7 +61,9 @@ class Rot_Footprint(BaseFilter):  # noqa: F821
             """ Extends the internal list of rotations with the one provided.
                 Otherwise just use the provided list """
             self.negative_bottom = True
-            """ Rotation for bottom components is computed substracting """
+            """ Rotation for bottom components is computed via substracting """
+            self.invert_bottom = False
+            """ Rotation for bottom components is negated """
             self.rotations = Optionable
             """ [list(list(string))] A list of pairs regular expression/rotation.
                 Components matching the regular expression will be rotated the indicated angle """
@@ -96,6 +98,8 @@ class Rot_Footprint(BaseFilter):  # noqa: F821
                     comp.footprint_rot -= angle
                 else:
                     comp.footprint_rot += angle
+                if self.invert_bottom and comp.bottom:
+                    comp.footprint_rot = -comp.footprint_rot
                 comp.footprint_rot = comp.footprint_rot % 360
                 if GS.debug_level > 2:
                     logger.debug('Rotating ref: {} {}: {} -> {}'.


### PR DESCRIPTION
Thanks for considering this PR implementing the solution proposed in #60.

Firstly, it was very gratifying to see the resulting correctly rotated part on the PCB:NG placement view. No manual rotation required. Yay.
<img src="https://user-images.githubusercontent.com/1261725/113868015-391f7080-977d-11eb-8f61-b5301207d487.png" width="150">

One extra feature that I found necessary was the ability to select all parts on the bottom of the board, because I didn't want any rotation applied to the top parts.

I implemented this by appending the board `side` ("_top" or "_bottom") to the footprint name prior to matching. A user can match on "_bottom" or "_top" to select components on a single side. Because it's all one `match_string` users can select components of a specific type on a side, too, using "^MyFootprint.*_top", for instance.

This is a potentially breaking change, depending on how users have created their match strings. It does not break any of the built-in rotations, all of which search for patterns at the beginnings of footprint names. But any matches attached to the end of the footprint name ("pattern$") will break.

I look forward to feedback about sensitivity to such a change and alternative ways to go.