### PR TITLE
KiCad 6: Catch environment.vars==None case 

### DIFF
--- a/kibot/kicad/config.py
+++ b/kibot/kicad/config.py
@@ -207,7 +207,7 @@ class KiConf(object):
         """ Environment vars from KiCad 6 configuration """
         with open(cfg, 'rt') as f:
             data = json.load(f)
-        if "environment" in data and 'vars' in data['environment']:
+        if "environment" in data and 'vars' in data['environment'] and (data['environment']['vars'] != None):
             for k, v in data['environment']['vars'].items():
                 if GS.debug_level > 1:
                     logger.debug('- KiCad var: {}="{}"'.format(k, v))


### PR DESCRIPTION
~~To be honest I don't understand all the code (yet), but with this change `$ kibot print_sch` works together with Kicad 6.0, because the `Junction`s does not seem to have UUIDs.~~

Commit 7bdc1f5 fixes a crash in case the `config_common.json` config file is present and contain a `vars` in `environment`, but the value is `None` (null). This is the case at least on a freshly installed Kicad on Linux/Ubuntu.