### PR TITLE
remove slashes from net names

### DIFF
--- a/kibot/out_boardview.py
+++ b/kibot/out_boardview.py
@@ -85,9 +85,11 @@ def convert(pcb, brd):
               .format(count=len(net_items)))
     for net_item in net_items:
         code = net_item.GetNet() if GS.ki5() else net_item.GetNetCode()
+        # if net name contains slashes (due to hierarchical sheets), use part after final slash
+        name = net_item.GetNetname().rsplit('/', 1)[-1]
         brd.write("{code} {name}\n"
                   .format(code=code,
-                          name=net_item.GetNetname().replace(" ", u"\u00A0")))
+                          name=name.replace(" ", u"\u00A0")))
     brd.write("\n")
 
     # Parts


### PR DESCRIPTION
In case net names contain slashes (due to hierarchical sheets), openboardview only shows the part after the final slash, including the slash.
Additionally, it truncates anything after an underscore in this case, including the underscore character.

Only keeping the part after the final slash maintains underscores and what follows, and it looks nicer without the preceding slash.