### PR TITLE
Allow expansion of environment variables in paths

### DIFF
--- a/kibot/config_reader.py
+++ b/kibot/config_reader.py
@@ -357,6 +357,7 @@ class CfgYamlReader(object):
                     config_error("`import` entry without `file` ({})".format(str(entry)))
             else:
                 config_error("`import` items must be strings or dicts ({})".format(str(entry)))
+            fn = os.path.expandvars(os.path.expanduser(fn))
             if not os.path.isabs(fn):
                 fn = os.path.join(dir, fn)
             if not os.path.isfile(fn):

--- a/kibot/out_kibom.py
+++ b/kibot/out_kibom.py
@@ -378,7 +378,9 @@ class KiBoMOptions(BaseOptions):
         kibom_command = self.ensure_tool('KiBoM')
         format = self.format.lower()
         prj = GS.sch_no_ext
-        config = os.path.join(GS.sch_dir, self.conf)
+        config = os.path.expandvars(os.path.expanduser(self.conf))
+        if not os.path.isabs(config):
+            config = os.path.join(GS.sch_dir, config)
         if self.output:
             force_output = True
             output = name

--- a/kibot/out_report.py
+++ b/kibot/out_report.py
@@ -212,6 +212,8 @@ class ReportOptions(BaseOptions):
         if self.template.lower() in ('full', 'simple', 'full_svg'):
             self.template = os.path.abspath(os.path.join(os.path.dirname(__file__), 'report_templates',
                                             'report_'+self.template.lower()+'.txt'))
+        if not os.path.isabs(self.template):
+            self.template = os.path.expandvars(os.path.expanduser(self.template))
         if not os.path.isfile(self.template):
             raise KiPlotConfigurationError("Missing report template: `{}`".format(self.template))
         m = re.match(r'(\d+)([A-F])', self.eurocircuits_class_target)


### PR DESCRIPTION
This allows using environment variable expansion in paths for importing outputs from other configuration files or specifying the KiBoM configuration file.

For example in "import" section:
```
import:
  - file: '${KIBOT_CFG}/config.yaml'
  - file: '~/some_config.yaml'
```
