### PR TITLE
Added in SCH PDF Print: An all_pages option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2340,6 +2340,7 @@ Notes:
         - `dnf_filter`: [string|list(string)='_none'] Name of the filter to mark components as not fitted.
                         A short-cut to use for simple cases where a variant is an overkill.
         - `monochrome`: [boolean=false] Generate a monochromatic PDF.
+        - `all_pages`: [boolean=true] Generate with all hierarchical sheets.
         - `output`: [string='%f-%i%I%v.%x'] Filename for the output PDF (%i=schematic, %x=pdf). Affected by global options.
         - `variant`: [string=''] Board variant to apply.
                      Not fitted components are crossed.
@@ -2808,6 +2809,7 @@ Notes:
         - `dnf_filter`: [string|list(string)='_none'] Name of the filter to mark components as not fitted.
                         A short-cut to use for simple cases where a variant is an overkill.
         - `monochrome`: [boolean=false] Generate a monochromatic PDF.
+        - `all_pages`: [boolean=true] Generate with all hierarchical sheets.
         - `output`: [string='%f-%i%I%v.%x'] Filename for the output SVG (%i=schematic, %x=svg). Affected by global options.
         - `variant`: [string=''] Board variant to apply.
                      Not fitted components are crossed.

--- a/docs/samples/generic_plot.kibot.yaml
+++ b/docs/samples/generic_plot.kibot.yaml
@@ -1281,6 +1281,8 @@ outputs:
       frame: true
       # [boolean=false] Generate a monochromatic PDF
       monochrome: false
+      # [boolean=true] Generate with all hierarchical sheets.
+      all_pages: true
       # [string='%f-%i%I%v.%x'] Filename for the output PDF (%i=schematic, %x=pdf). Affected by global options
       output: '%f-%i%I%v.%x'
       # [string=''] Board variant to apply.
@@ -1709,6 +1711,8 @@ outputs:
       frame: true
       # [boolean=false] Generate a monochromatic PDF
       monochrome: false
+      # [boolean=true] Generate with all hierarchical sheets.
+      all_pages: true
       # [string='%f-%i%I%v.%x'] Filename for the output SVG (%i=schematic, %x=svg). Affected by global options
       output: '%f-%i%I%v.%x'
       # [string=''] Board variant to apply.

--- a/kibot/out_any_sch_print.py
+++ b/kibot/out_any_sch_print.py
@@ -37,6 +37,8 @@ class Any_SCH_PrintOptions(VariantOptions):
             """ Generate a monochromatic PDF """
             self.frame = True
             """ *Include the frame and title block """
+            self.all_pages = True
+            """ Generate with all hierarchical sheets """
         super().__init__()
         self.add_to_doc('variant', "Not fitted components are crossed")
         self._expand_id = 'schematic'
@@ -60,11 +62,13 @@ class Any_SCH_PrintOptions(VariantOptions):
         else:
             sch_dir = None
             sch_file = GS.sch_file
-        cmd = [command, 'export', '--all_pages', '--file_format', self._expand_ext]
+        cmd = [command, 'export', '--file_format', self._expand_ext]
         if self.monochrome:
             cmd.append('--monochrome')
         if not self.frame:
             cmd.append('--no_frame')
+        if self.all_pages:
+            cmd.append('--all_pages')
         cmd.extend([sch_file, output_dir])
         cmd, video_remove = add_extra_options(cmd)
         ret = exec_with_retry(cmd)


### PR DESCRIPTION
Support exporting the root schematic only as in KiAuto without the `--all_pages` option. Thanks.