### PR TITLE
Suppress an excessive info message to console

### DIFF
--- a/kibot/kiplot.py
+++ b/kibot/kiplot.py
@@ -668,7 +668,6 @@ def solve_board_file(base_dir, a_board_file=None, sug_b=True):
         pcb = os.path.join(base_dir, os.path.splitext(schematic)[0]+'.kicad_pcb')
         if os.path.isfile(pcb):
             board_file = pcb
-            logger.info('Using PCB file: '+os.path.relpath(board_file))
     if not board_file:
         board_files = glob(os.path.join(base_dir, '*.kicad_pcb'))
         if len(board_files) == 1:


### PR DESCRIPTION
It seems that KiBot prints excessive and somewhat misleading info to the console while exporting schematic files:
```
Using PCB file: the/path/to/the/file.kicad_pcb # may confuse users
- 'Export schematic (sch) [pdf_sch_print]'     # may differ, based on YAML configs
```
This would not happen when exporting PCB layout files as `solve_schematic` does not print the `Using SCH file` hint to the console if `not schematic and a_board_file` holds. Thus, for symmetry and reducing potentially misleading wordings, I prefer suppress this info message. The hint would still be dumped when debug level is set. Thanks.