### PR TITLE
Save converted design report to same directory as text report

### DIFF
--- a/kibot/out_report.py
+++ b/kibot/out_report.py
@@ -730,7 +730,7 @@ class ReportOptions(BaseOptions):
         if not self.do_convert:
             return
         command = self.ensure_tool('PanDoc')
-        out = self.expand_converted_output(GS.out_dir)
+        out = self.expand_converted_output(os.path.dirname(os.path.abspath(fname)))
         logger.debug('Converting the report to: {}'.format(out))
         resources = '--resource-path='+GS.out_dir
         # Pandoc 2.2.1 doesn't support "--to pdf"


### PR DESCRIPTION
The output file generated when using the 'do_convert' option for the report output was saved to the main project directory. This caused an error when using the report output as input in a 'compress' output.
I changed the output path for the converted file so that it is stored in the same location as the .txt report, i.e. the directory specified in 'dir'