### PR TITLE
catch possible SSLError when downloading datasheets

### DIFF
--- a/kibot/out_download_datasheets.py
+++ b/kibot/out_download_datasheets.py
@@ -68,6 +68,9 @@ class Download_Datasheets_Options(VariantOptions):
                 except requests.exceptions.ReadTimeout:
                     logger.warning(W_FAILDL+'Timeout during download `{}`'.format(ds))
                     return None
+                except requests.exceptions.SSLError:
+                    logger.warning(W_FAILDL+'SSL Error during download `{}`'.format(ds))
+                    return None
                 if r.status_code != 200:
                     logger.warning(W_FAILDL+'Failed to download `{}`'.format(ds))
                     return None


### PR DESCRIPTION
This is just a small fix that prevents KiBot from crashing if an 'SSLError' is raised while downloading datasheets, e. g. this would happen if the server certificate expired. Previously this would cause KiBot to crash, now a warning is shown.