### PR TITLE
Update user agent string to pretend being a recent version of Firefox

### DIFF
--- a/kibot/misc.py
+++ b/kibot/misc.py
@@ -241,7 +241,7 @@ SILK_COLORS = {'black': "0b1013", 'white': "d5dce4"}
 # KiCad 6 uses IUs for SVGs, but KiCad 5 uses a very different scale based on inches
 KICAD5_SVG_SCALE = 116930/297002200
 # Some browser name to pretend
-USER_AGENT = 'Mozilla/5.0 (Windows NT 5.2; rv:2.0.1) Gecko/20100101 Firefox/4.0.1'
+USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0'
 
 
 class Rect(object):


### PR DESCRIPTION
This small fix changes the user agent string to what would be reported by a recent version of Firefox.

Previously KiBot pretended to be a rather old version of Firefox which for some reason creates issues when trying to download datasheets from certain servers:
```
WARNING:(W048) Failed to download `https://media.digikey.com/pdf/Data%20Sheets/Samsung%20PDFs/CL05C100JB5NNNC_Spec.pdf` (kibot - out_download_datasheets.py:75)
WARNING:(W048) Timeout during download `https://www.phoenixcontact.com/us/products/1999000/pdf` (kibot - out_download_datasheets.py:69)
WARNING:(W048) Timeout during download `https://www.phoenixcontact.com/us/products/1847479/pdf` (kibot - out_download_datasheets.py:69)
WARNING:(W048) Timeout during download `https://www.phoenixcontact.com/us/products/1843855/pdf` (kibot - out_download_datasheets.py:69)
```
However these servers will work just fine when provided with a recent user agent string.