### PR TITLE
fix typo

### DIFF
--- a/kibot/PcbDraw/plot.py
+++ b/kibot/PcbDraw/plot.py
@@ -800,7 +800,7 @@ class PlotComponents(PlotInterface):
             ret = self._create_component(lib, name, ref, value)
             if ret is None:
                 if name[-5:] != '.back' or not self.no_warn_back:
-                    self._plotter.yield_warning("component", f"Component {lib}:{name} has not footprint.")
+                    self._plotter.yield_warning("component", f"Component {lib}:{name} has no footprint.")
                 return
             component_element, component_info = ret
             self._used_components[unique_name] = component_info
@@ -839,7 +839,7 @@ class PlotComponents(PlotInterface):
             origin_x, origin_y = element_position(origin, root=component_element)
             origin.getparent().remove(origin)
         else:
-            self._plotter.yield_warning("origin", f"component: Component {lib}:{name} has not origin")
+            self._plotter.yield_warning("origin", f"component: Component {lib}:{name} has no origin")
         svg_scale_x, svg_scale_y, svg_offset_x, svg_offset_y = self._component_to_board_scale_and_offset(svg_tree)
         component_info = PlacedComponentInfo(
             id=xml_id,


### PR DESCRIPTION
Easy typo to fix, there may be more that I didn't see on the first pass:

https://github.com/ModischFabrications/EasyLight_PCB/actions/runs/4028365312/jobs/6925162088 -> 
```
WARNING:(W103) (component) Component lcsc:SOT-23-3_L2.9-W1.3-P1.90-LS2.4-BR has not footprint. (kibot - out_pcbdraw.py:45)
WARNING:(W103) (component) Component LCSC:SMB_L4.6-W3.6-LS5.3-BI has not footprint. (kibot - out_pcbdraw.py:45)
WARNING:(W103) (component) Component LCSC:SMA_L4.3-W2.6-LS5.2-RD has not footprint. (kibot - out_pcbdraw.py:45)
WARNING:(W103) (component) Component LCSC:SOT-23-6_L2.9-W1.6-P0.95-LS2.8-BR has not footprint. (kibot - out_pcbdraw.py:45)
WARNING:(W103) (component) Component LCSC:SOIC-8_L4.9-W3.9-P1.27-LS6.0-BL-EP3.3-1 has not footprint. (kibot - out_pcbdraw.py:45)
WARNING:(W103) (component) Component LCSC:SW-SMD_4P-L5.1-W5.1-P3.70-LS6.5-TL-2 has not footprint. (kibot - out_pcbdraw.py:45)
```