### PR TITLE
Fix type error

### DIFF
--- a/kibot/out_report.py
+++ b/kibot/out_report.py
@@ -49,9 +49,7 @@ def do_round(v, dig):
 
 def to_mm(iu, dig=2):
     """ KiCad Internal Units to millimeters """
-    if isinstance(iu, pcbnew.wxPoint):
-        return (do_round(GS.to_mm(iu.x), dig), do_round(GS.to_mm(iu.y), dig))
-    if isinstance(iu, pcbnew.wxSize):
+    if hasattr(iu, 'x'):
         return (do_round(GS.to_mm(iu.x), dig), do_round(GS.to_mm(iu.y), dig))
     return do_round(GS.to_mm(iu), dig)
 


### PR DESCRIPTION
Uses duck-typing for the test instead of requiring the type be one of a few specific instances. This fixes the following error I get with kicad v7.0.4: `TypeError: float() argument must be a string or a real number, not 'VECTOR2I'`