### PR TITLE
Update AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 * [Installation](#installation)
   * [Dependencies](#dependencies)
   * [Installation on Ubuntu or Debian](#installation-on-ubuntu-or-debian)
+  * [Installation on Arch Linux](#installation-on-arch-linux)
   * [Installation using pip](#installation-using-pip)
   * [Notes about virtualenv](#notes-about-virtualenv)
   * [Installation on other targets](#installation-on-other-targets)
@@ -260,6 +261,15 @@ sudo apt install ./python3-mcpy_2.0.2-1_all.deb ./kibot_0.6.0-1_all.deb
 
 **Important note**: The [KiCad Automation Scripts](https://github.com/INTI-CMNB/kicad-automation-scripts/) packages are a mandatory dependency.
 The [KiBoM](https://github.com/INTI-CMNB/KiBoM), [InteractiveHtmlBom](https://github.com/INTI-CMNB/InteractiveHtmlBom) and [PcbDraw](https://github.com/INTI-CMNB/PcbDraw) are recommended.
+
+
+### Installation on Arch Linux
+
+AUR repository for [kibot](https://aur.archlinux.org/packages/kibot)
+
+```shell
+yay -S kibot
+```
 
 ### Installation using pip
 


### PR DESCRIPTION
```bash
❯ kibot-check  
KiBot installation checker

Core:
Linux: 6.4.3.1 (Linux archlinux 6.4.3-1-ck-generic-v3 #1 SMP PREEMPT_DYNAMIC Wed Jul 12 17:17:50 EDT 2023 x86_64 GNU/Linux)
Python: 3.11.3 (main, Jun 12 2023, 13:08:57) [GCC 13.1.1 20230429]
KiCad: 7.99.0-1969-ga343cd0a24
Kibot: 1.6.3

Modules:
Colorama: 0.4.6
LXML: 4.9.2
Lark: 1.1.5
PyYAML: 6.0.0 (6.0)
QRCodeGen: Ok
Requests: 2.28.2
XLSXWriter: 3.1.0
Xvfbwrapper: Ok
markdown2: 2.4.8
mistune: 2.0.5
numpy: 1.25.1

Tools:
Bash: 5.1.16 (GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu))
Blender: 3.6.0 (Blender 3.6.0)
Ghostscript: 10.1.2 (10.01.2)
Git: 2.41.0 (git version 2.41.0)
ImageMagick: 7.1.1.14 (Version: ImageMagick 7.1.1-14 Q16-HDRI x86_64 21286 https://imagemagick.org)
Interactive HTML BoM: 2.5.0 (Git version check failed: Command '['git', 'describe', '--tags', '--abbrev=4', '--dirty=-*']' returned non-zero exit status 128.)
KiBoM: 1.9.0 (KiBOM Version: 1.9.0)
KiCad Automation tools (kiauto): 2.2.6 (pcbnew_do 2.2.6 - Copyright 2018-2023, INTI/Productize SPRL - License: Apache)
KiCad PCB/SCH Diff (kidiff): 2.4.7 (kicad-diff.py 2.4.7 - Copyright 2020-2023, INTI/Salvador E. Tropea - License:)
KiCost: 1.1.17 (KiCost v1.1.17)
KiKit: 1.3.0 (kikit, version 1.3.0)
OpenSCAD: 2021.1.0 (OpenSCAD version 2021.01)
Pandoc: 3.1.6 (pandoc 3.1.6)
RAR: 6.22.0 (RAR 6.22   Copyright (c) 1993-2023 Alexander Roshal   29 May 2023)
RSVG tools: 2.56.3 (rsvg-convert version 2.56.3)
Xvfb: Ok (xvfb-run)

* KiKit not installed or too old
  Visit: https://github.com/yaqwsx/KiKit
  Download it from: https://github.com/yaqwsx/KiKit/releases
  This tool might be automatically downloaded by KiBot.
  - Mandatory for: `panelize`, `stencil_3d`, `stencil_for_jig`
  - Optional to separate multiboard projects for general use


Color reference: ok, optional for an output, optional for general use, mandatory for an output, mandatory for general use

Did this help? Please consider commenting it on https://github.com/INTI-CMNB/KiBot/discussions/categories/kibot-check

```