### PR TITLE
Fix blender_export (pcb2blender): rename argument center_pcb -> center_boards

### DIFF
--- a/kibot/blender_scripts/blender_export.py
+++ b/kibot/blender_scripts/blender_export.py
@@ -354,7 +354,7 @@ def main():
     bpy.ops.pcb2blender.import_pcb3d(filepath=PCB3D_file, pcb_material=args.pcb_material,
                                      import_components=args.no_components,
                                      add_solder_joints=args.solder_joints,
-                                     center_pcb=args.dont_center,
+                                     center_boards=args.dont_center,
                                      merge_materials=args.dont_merge_materials,
                                      enhance_materials=args.dont_enhance_materials,
                                      cut_boards=args.dont_cut_boards,


### PR DESCRIPTION
The argument of the tool pcb2blender is now `center_boards`