### PR TITLE
Handle Symbol Unit Custom Names

### DIFF
--- a/kibot/kicad/v6_sch.py
+++ b/kibot/kicad/v6_sch.py
@@ -744,6 +744,7 @@ class LibComponent(object):
         self.on_board = True
         self.is_power = False
         self.unit = 0
+        self.unit_name = None
         self.draw = []
         self.fields = []
         self.dfields = {}
@@ -787,6 +788,7 @@ class LibComponent(object):
             if parent is None:
                 logger.warning(W_NOLIB + "Component `{}` with more than one `:`".format(comp.name))
         comp.units = []
+        comp.unit_name = ''
         comp.pins = []
         comp.all_pins = []
         comp.unit_count = 1
@@ -865,6 +867,12 @@ class LibComponent(object):
                     raise SchError('Malformed unit id `{}`'.format(vis_obj.lib_id))
                 unit = int(m.group(2))
                 comp.unit_count = max(unit, comp.unit_count)
+            # UNIT_NAMES...
+            elif i_type == 'unit_name':
+                # Units can have custom labels 
+                # The format is not documented but as of V7 is: 
+                # (unit_name "<NAME>")
+                comp.unit_name = i[1] 
             else:
                 raise SchError('Unknown symbol attribute `{}`'.format(i))
             if vis_obj:


### PR DESCRIPTION
Hi @set-soft,

Firstly, thank you for all your hard work on kibot and associated tools.

The intention of this pull request is to add handling of custom unit names, as described in: 
https://docs.kicad.org/7.0/en/eeschema/eeschema.html#creating-and-editing-symbols
(can't link to the exact subsection, search for 'Set Unit Display Name')

Kibot (v1.6.3) gives the following error if a symbol with a custom unit name is used:
```ERROR:Unknown symbol attribute `[Symbol('unit_name'), '<UNIT NAME>']` (kibot.gs - gs.py:731)```

The sexpr formatting isn't described in: https://dev-docs.kicad.org/en/file-formats/sexpr-schematic/
But is pretty basic: `(unit_name "<UNIT NAME>")` 

I have added handling of this field, and stored it in the LibComponent object.

A minimum reproducable project can be found here:
https://github.com/Andrew-Collins/unit_name_mrp.git
