### PR TITLE
Fix handling of hierarchical branches with a depth >2 

### DIFF
--- a/kibot/kicad/v6_sch.py
+++ b/kibot/kicad/v6_sch.py
@@ -1649,7 +1649,7 @@ class Sheet(object):
         self.sheet = sheet
         parent_dir = os.path.dirname(parent_file)
         sheet.sheet_path = path_join(parent_obj.sheet_path, self.uuid)
-        sheet.sheet_path_ori = path_join(parent_obj.sheet_path, self.uuid_ori)
+        sheet.sheet_path_ori = path_join(parent_obj.sheet_path_ori, self.uuid_ori)
         sheet.sheet_path_h = path_join(parent_obj.sheet_path_h, self.name)
         parent_obj.sheet_paths[sheet.sheet_path_ori] = sheet
         sheet.load(os.path.join(parent_dir, self.file), project, parent_obj)


### PR DESCRIPTION
Hi @set-soft,

I was getting the following error type:
```ERROR:While loading `/home/ac/work/kibot-heirachal-test/kibot-heirachal-test.kicad_sch` (kibot.gs - gs.py:751)
ERROR:Missing R symbol instance for `/2f7bf752-fced-400e-aa47-c202d1ff4cb6/91fd3c38-308c-4a0d-8dce-5c7dfcc46162/a5130e09-dadf-45c6-a20a-45a2acdafc58/a1b591db-7eff-4e8b-9266-52a5fd7ed10d` (kibot.gs - gs.py:751)```

When working with a sch tree akin to the following:
![image](https://github.com/INTI-CMNB/KiBot/assets/12761461/f19bf67b-3bfb-4b00-ae89-bd4d675d1dd7)
where A and A1 are copies of the same sheet.
Example project [here](https://github.com/Andrew-Collins/kibot-hierarchical-test).

I tracked this down to the `ori` path of each sheet being based on the parent's non-`ori` path.
This caused the uuid/path of the sheet to get out of whack with the `instances` fields in the `sch` file.

So this PR just bases the `ori` path off of the parent's `ori` path; hopefully without disturbing any logic elsewhere.