### PR TITLE
kiplot: Allow output dir to exist

### DIFF
--- a/kibot/kiplot.py
+++ b/kibot/kiplot.py
@@ -362,8 +362,8 @@ def get_output_dir(o_dir, obj, dry=False):
     outdir = os.path.abspath(obj.expand_dirname(os.path.join(GS.out_dir, o_dir)))
     # Create directory if needed
     logger.debug("Output destination: {}".format(outdir))
-    if not dry and not os.path.exists(outdir):
-        os.makedirs(outdir)
+    if not dry:
+        os.makedirs(outdir, exist_ok=True)
     return outdir
 
 


### PR DESCRIPTION
When running kibot, we check if a path exists. However, this seems to fail with for example symlinks, resulting in the following error.

```
Using SCH file: 1.kicad_sch
- 'Records information about the current run.' (info) [info]
Traceback (most recent call last):
  File "/usr/bin/kibot", line 33, in <module>
    sys.exit(load_entry_point('kibot==1.6.3', 'console_scripts', 'kibot')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kibot/__main__.py", line 520, in main
    generate_outputs(outputs, args.target, args.invert_sel, args.skip_pre, args.cli_order, args.no_priority,
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 527, in generate_outputs
    _generate_outputs(outputs, targets, invert, skip_pre, cli_order, no_priority, dont_stop)
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 517, in _generate_outputs
    run_output(out, dont_stop)
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 418, in run_output
    out.run(get_output_dir(out.dir, out))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 366, in get_output_dir
    os.makedirs(outdir)
  File "<frozen os>", line 225, in makedirs
FileExistsError: [Errno 17] File exists: '/my_path/reports'
```

Instead of manually determining things, lets just use os.makedirs to handle this with the `exists_ok` argument, as we do elsewhere.