### PR TITLE
[Diff][Fixed] Worktree's can leave junk branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `current`: didn't apply global variants
   - `current`: didn't honor KiCad native DNP flags, they need a filter
   - Problems when trying to use an already existent worktree (#555)
+  - Avoid using unexpected branches for worktrees (#556)
 - PCB Print:
   - Issues when forcing the board edge and using scaling (#532)
   - Text not searchable when using newer rsvg-convert tools (#552)

--- a/kibot/out_diff.py
+++ b/kibot/out_diff.py
@@ -373,7 +373,7 @@ class DiffOptions(AnyDiffOptions):
             name = self.solve_git_name(name)
             git_tmp_wd = mkdtemp()
             logger.debug('Checking out '+name+' to '+git_tmp_wd)
-            self.run_git(['worktree', 'add', '--force', git_tmp_wd, name])
+            self.run_git(['worktree', 'add', '--detach', '--force', git_tmp_wd, name])
             self._worktrees_to_remove.append(git_tmp_wd)
             self.run_git(['submodule', 'update', '--init', '--recursive'], cwd=git_tmp_wd)
             name_copy = self.run_git(['ls-files', '--full-name', self.file])

--- a/kibot/out_kiri.py
+++ b/kibot/out_kiri.py
@@ -285,7 +285,7 @@ class KiRiOptions(AnyDiffOptions):
                         rmtree(dst_dir)
                     git_tmp_wd = mkdtemp()
                     logger.debug('Checking out '+hash+' to '+git_tmp_wd)
-                    self.run_git(['worktree', 'add', '--force', git_tmp_wd, hash])
+                    self.run_git(['worktree', 'add', '--detach', '--force', git_tmp_wd, hash])
                     self.run_git(['submodule', 'update', '--init', '--recursive'], cwd=git_tmp_wd)
                     # Generate SVGs for the schematic
                     name_sch = self.do_cache(self.sch_rel_name, git_tmp_wd, hash)


### PR DESCRIPTION
When kibot creates a worktree, which in some cases creates a new branch
or uses an existing branch. This branch may be old and stale, and often
not what is expected.
    
Instead, avoid the issue entirely, by never creating anything that could
need cleaning up, by creating a detached worktree.
    
Fixes #556