### PR TITLE
pre_update: Honor 'board_only' (Not in schematic) footprint property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     This limitation isn't found on KiCad 7. (#486)
   - *exclude_from_bom* mismatch on KiCad 7
   - *Sheetfile* mismatch on KiCad 7 when testing from different directory
+  - Honor the 'Not in schematic' (board_only) flag when doing a parity check
 - Dependencies downloader:
   - Problems when connection timed-out
 - Sub PCB separation using annotation method for some edeges and KiCad

--- a/kibot/pre_update_xml.py
+++ b/kibot/pre_update_xml.py
@@ -86,7 +86,8 @@ class Update_XML(BasePreFlight):  # noqa: F821
                     logger.warning(W_NOTINBOM+f"{ref} excluded from BoM we can't check its parity, upgrade to KiCad 7")
                     excluded.add(ref)
                 else:
-                    errors.append('{} found in PCB, but not in schematic'.format(ref))
+                    if not m.GetAttributes() & MOD_BOARD_ONLY:
+                        errors.append('{} found in PCB, but not in schematic'.format(ref))
                 continue
             sch_data = comps[ref]
             pcb_fp = m.GetFPIDAsString()


### PR DESCRIPTION
It is quite common, to add footprints to a PCB, without adding it to the schematic. Think Logo's or 'duplicate' connectors etc. KiCad has a flag called 'Not in schematic' for this purpose. Lets check if this flag is set in the PCB, and ignore any errors from this if applicable.

Fixes: #558.