### PR TITLE
Add backticks around custom_reports docs to improve layout

### DIFF
--- a/docs/samples/generic_plot.kibot.yaml
+++ b/docs/samples/generic_plot.kibot.yaml
@@ -872,8 +872,8 @@ outputs:
     options:
       # [list(dict)] A list of customized reports for the manufacturer
       custom_reports:
-        # [string=''] Content for the report. Use `${basename}` for the project name without extension.
-        # Use `${filename(LAYER)}` for the file corresponding to LAYER
+        # [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+        # Use ``${filename(LAYER)}`` for the file corresponding to LAYER
         - content: ''
           # [string='Custom_report.txt'] File name for the custom report
           output: 'Custom_report.txt'
@@ -1100,8 +1100,8 @@ outputs:
       create_gerber_job_file: true
       # [list(dict)] A list of customized reports for the manufacturer
       custom_reports:
-        # [string=''] Content for the report. Use `${basename}` for the project name without extension.
-        # Use `${filename(LAYER)}` for the file corresponding to LAYER
+        # [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+        # Use ``${filename(LAYER)}`` for the file corresponding to LAYER
         - content: ''
           # [string='Custom_report.txt'] File name for the custom report
           output: 'Custom_report.txt'
@@ -1176,8 +1176,8 @@ outputs:
     options:
       # [list(dict)] A list of customized reports for the manufacturer
       custom_reports:
-        # [string=''] Content for the report. Use `${basename}` for the project name without extension.
-        # Use `${filename(LAYER)}` for the file corresponding to LAYER
+        # [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+        # Use ``${filename(LAYER)}`` for the file corresponding to LAYER
         - content: ''
           # [string='Custom_report.txt'] File name for the custom report
           output: 'Custom_report.txt'
@@ -2626,8 +2626,8 @@ outputs:
     options:
       # [list(dict)] A list of customized reports for the manufacturer
       custom_reports:
-        # [string=''] Content for the report. Use `${basename}` for the project name without extension.
-        # Use `${filename(LAYER)}` for the file corresponding to LAYER
+        # [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+        # Use ``${filename(LAYER)}`` for the file corresponding to LAYER
         - content: ''
           # [string='Custom_report.txt'] File name for the custom report
           output: 'Custom_report.txt'
@@ -2891,8 +2891,8 @@ outputs:
       a4_output: true
       # [list(dict)] A list of customized reports for the manufacturer
       custom_reports:
-        # [string=''] Content for the report. Use `${basename}` for the project name without extension.
-        # Use `${filename(LAYER)}` for the file corresponding to LAYER
+        # [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+        # Use ``${filename(LAYER)}`` for the file corresponding to LAYER
         - content: ''
           # [string='Custom_report.txt'] File name for the custom report
           output: 'Custom_report.txt'
@@ -3375,8 +3375,8 @@ outputs:
     options:
       # [list(dict)] A list of customized reports for the manufacturer
       custom_reports:
-        # [string=''] Content for the report. Use `${basename}` for the project name without extension.
-        # Use `${filename(LAYER)}` for the file corresponding to LAYER
+        # [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+        # Use ``${filename(LAYER)}`` for the file corresponding to LAYER
         - content: ''
           # [string='Custom_report.txt'] File name for the custom report
           output: 'Custom_report.txt'

--- a/docs/source/configuration/outputs/dxf.rst
+++ b/docs/source/configuration/outputs/dxf.rst
@@ -48,8 +48,8 @@ Parameters:
 
          -  Valid keys:
 
-            -  ``content`` :index:`: <pair: output - dxf - options - custom_reports; content>` [string=''] Content for the report. Use `${basename}` for the project name without extension.
-               Use `${filename(LAYER)}` for the file corresponding to LAYER.
+            -  ``content`` :index:`: <pair: output - dxf - options - custom_reports; content>` [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+               Use ``${filename(LAYER)}`` for the file corresponding to LAYER.
             -  ``output`` :index:`: <pair: output - dxf - options - custom_reports; output>` [string='Custom_report.txt'] File name for the custom report.
 
       -  ``dnf_filter`` :index:`: <pair: output - dxf - options; dnf_filter>` [string|list(string)='_none'] Name of the filter to mark components as not fitted.

--- a/docs/source/configuration/outputs/gerber.rst
+++ b/docs/source/configuration/outputs/gerber.rst
@@ -53,8 +53,8 @@ Parameters:
 
          -  Valid keys:
 
-            -  ``content`` :index:`: <pair: output - gerber - options - custom_reports; content>` [string=''] Content for the report. Use `${basename}` for the project name without extension.
-               Use `${filename(LAYER)}` for the file corresponding to LAYER.
+            -  ``content`` :index:`: <pair: output - gerber - options - custom_reports; content>` [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+               Use ``${filename(LAYER)}`` for the file corresponding to LAYER.
             -  ``output`` :index:`: <pair: output - gerber - options - custom_reports; output>` [string='Custom_report.txt'] File name for the custom report.
 
       -  ``disable_aperture_macros`` :index:`: <pair: output - gerber - options; disable_aperture_macros>` [boolean=false] Disable aperture macros (workaround for buggy CAM software) (KiCad 6).

--- a/docs/source/configuration/outputs/hpgl.rst
+++ b/docs/source/configuration/outputs/hpgl.rst
@@ -47,8 +47,8 @@ Parameters:
 
          -  Valid keys:
 
-            -  ``content`` :index:`: <pair: output - hpgl - options - custom_reports; content>` [string=''] Content for the report. Use `${basename}` for the project name without extension.
-               Use `${filename(LAYER)}` for the file corresponding to LAYER.
+            -  ``content`` :index:`: <pair: output - hpgl - options - custom_reports; content>` [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+               Use ``${filename(LAYER)}`` for the file corresponding to LAYER.
             -  ``output`` :index:`: <pair: output - hpgl - options - custom_reports; output>` [string='Custom_report.txt'] File name for the custom report.
 
       -  ``dnf_filter`` :index:`: <pair: output - hpgl - options; dnf_filter>` [string|list(string)='_none'] Name of the filter to mark components as not fitted.

--- a/docs/source/configuration/outputs/pdf.rst
+++ b/docs/source/configuration/outputs/pdf.rst
@@ -50,8 +50,8 @@ Parameters:
 
          -  Valid keys:
 
-            -  ``content`` :index:`: <pair: output - pdf - options - custom_reports; content>` [string=''] Content for the report. Use `${basename}` for the project name without extension.
-               Use `${filename(LAYER)}` for the file corresponding to LAYER.
+            -  ``content`` :index:`: <pair: output - pdf - options - custom_reports; content>` [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+               Use ``${filename(LAYER)}`` for the file corresponding to LAYER.
             -  ``output`` :index:`: <pair: output - pdf - options - custom_reports; output>` [string='Custom_report.txt'] File name for the custom report.
 
       -  ``dnf_filter`` :index:`: <pair: output - pdf - options; dnf_filter>` [string|list(string)='_none'] Name of the filter to mark components as not fitted.
@@ -99,8 +99,8 @@ Parameters:
 
    -  Valid keys:
 
-      -  ``content`` :index:`: <pair: output - pdf - custom_reports; content>` [string=''] Content for the report. Use `${basename}` for the project name without extension.
-         Use `${filename(LAYER)}` for the file corresponding to LAYER.
+      -  ``content`` :index:`: <pair: output - pdf - custom_reports; content>` [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+         Use ``${filename(LAYER)}`` for the file corresponding to LAYER.
       -  ``output`` :index:`: <pair: output - pdf - custom_reports; output>` [string='Custom_report.txt'] File name for the custom report.
 
 -  ``disable_run_by_default`` :index:`: <pair: output - pdf; disable_run_by_default>` [string|boolean] Use it to disable the `run_by_default` status of other output.

--- a/docs/source/configuration/outputs/ps.rst
+++ b/docs/source/configuration/outputs/ps.rst
@@ -50,8 +50,8 @@ Parameters:
 
          -  Valid keys:
 
-            -  ``content`` :index:`: <pair: output - ps - options - custom_reports; content>` [string=''] Content for the report. Use `${basename}` for the project name without extension.
-               Use `${filename(LAYER)}` for the file corresponding to LAYER.
+            -  ``content`` :index:`: <pair: output - ps - options - custom_reports; content>` [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+               Use ``${filename(LAYER)}`` for the file corresponding to LAYER.
             -  ``output`` :index:`: <pair: output - ps - options - custom_reports; output>` [string='Custom_report.txt'] File name for the custom report.
 
       -  ``dnf_filter`` :index:`: <pair: output - ps - options; dnf_filter>` [string|list(string)='_none'] Name of the filter to mark components as not fitted.

--- a/docs/source/configuration/outputs/svg.rst
+++ b/docs/source/configuration/outputs/svg.rst
@@ -50,8 +50,8 @@ Parameters:
 
          -  Valid keys:
 
-            -  ``content`` :index:`: <pair: output - svg - options - custom_reports; content>` [string=''] Content for the report. Use `${basename}` for the project name without extension.
-               Use `${filename(LAYER)}` for the file corresponding to LAYER.
+            -  ``content`` :index:`: <pair: output - svg - options - custom_reports; content>` [string=''] Content for the report. Use ``${basename}`` for the project name without extension.
+               Use ``${filename(LAYER)}`` for the file corresponding to LAYER.
             -  ``output`` :index:`: <pair: output - svg - options - custom_reports; output>` [string='Custom_report.txt'] File name for the custom report.
 
       -  ``dnf_filter`` :index:`: <pair: output - svg - options; dnf_filter>` [string|list(string)='_none'] Name of the filter to mark components as not fitted.

--- a/kibot/out_any_layer.py
+++ b/kibot/out_any_layer.py
@@ -36,8 +36,8 @@ class CustomReport(Optionable):
             self.output = 'Custom_report.txt'
             """ File name for the custom report """
             self.content = ''
-            """ Content for the report. Use `${basename}` for the project name without extension.
-                Use `${filename(LAYER)}` for the file corresponding to LAYER """
+            """ Content for the report. Use ``${basename}`` for the project name without extension.
+                Use ``${filename(LAYER)}`` for the file corresponding to LAYER """
 
 
 class AnyLayerOptions(VariantOptions):


### PR DESCRIPTION
Continuation of #517 

Prevents markdown from detecting and formatting it as math