### PR TITLE
[BoM][Fixed] Generate color ref for xlsx output

### DIFF
--- a/kibot/bom/xlsx_writer.py
+++ b/kibot/bom/xlsx_writer.py
@@ -248,7 +248,7 @@ def insert_logo(worksheet, image_data, scale):
 
 
 def create_color_ref(workbook, col_colors, hl_empty, fmt_cols, do_kicost, kicost_colors, row_colors):
-    if not (col_colors or do_kicost):
+    if not (col_colors or row_colors or do_kicost):
         return
     row = 0
     worksheet = workbook.add_worksheet('Colors')


### PR DESCRIPTION
When generating BoM in xlsx format the color reference is not generated when row_colors is enabled but col_colors is disabled. This change generates the color reference if either col_colors or row_colors are enabled.