### PR TITLE
[PCB Print][Fixed] Allow colons in sheet and layer_var expansions

### DIFF
--- a/kibot/optionable.py
+++ b/kibot/optionable.py
@@ -550,11 +550,11 @@ class Optionable(object):
             logger.debug('Expanded `{}`'.format(name))
         return name
 
-    def expand_filename_pcb(self, name):
+    def expand_filename_pcb(self, name, make_safe=True):
         """ Expands %* values in filenames.
             Uses data from the PCB. """
         # This member can be called with a preflight object
-        return Optionable.expand_filename_both(self, name, is_sch=False)
+        return Optionable.expand_filename_both(self, name, is_sch=False, make_safe=make_safe)
 
     def expand_filename_sch(self, name):
         """ Expands %* values in filenames.

--- a/kibot/out_pcb_print.py
+++ b/kibot/out_pcb_print.py
@@ -248,7 +248,7 @@ class PagesOptions(Optionable):
             sheet = sheet.replace('%ln', layer.layer)
             sheet = sheet.replace('%ls', layer.suffix)
             sheet = sheet.replace('%ld', layer.description)
-        return self.expand_filename_pcb(sheet)
+        return self.expand_filename_pcb(sheet, make_safe=False)
 
     def config(self, parent):
         super().config(parent)


### PR DESCRIPTION
This PR sets the `make_safe` flag option to `False` for the `expand_sheet_patterns` function of PCB Print to allow colons in `layer_var` and `sheet` text expansions. Previously, the colons were replaced with `_`.

Example with `layer_var`:

Before:
![image](https://github.com/user-attachments/assets/4e428c90-7a50-4f3c-9c4e-c4a3c63352c3)
After
![image](https://github.com/user-attachments/assets/f8fb51d6-f36b-4206-ae9b-2bd18c905670)
