### PR TITLE
[Fix] fix get_csv_separator() function for BoM class

### DIFF
--- a/kibot/out_bom.py
+++ b/kibot/out_bom.py
@@ -1005,7 +1005,7 @@ class BoM(BaseOutput):  # noqa: F821
         self._category = 'Schematic/BoM'
 
     def get_csv_separator(self):
-        return self.csv.separator
+        return self.options.csv.separator
 
     @staticmethod
     def create_bom(fmt, subd, group_fields, join_fields, fld_names, cols=None):


### PR DESCRIPTION
This PR fixes the get_csv_separator() function for the BoM class, which raises the error:
`'BoM' object has no attribute 'csv'`