### PR TITLE
[Fix][Include Table] Use correct output parameters w.r.t. CSV files

### DIFF
--- a/kibot/pre_include_table.py
+++ b/kibot/pre_include_table.py
@@ -246,7 +246,7 @@ def update_table(ops, parent):
             csv_name.append(name_without_ext)
 
         # Map the CSV file names to the corresponding out variable
-        out_to_csv_mapping[out.name] = csv_targets
+        out_to_csv_mapping[out.name] = (out, csv_targets)
         logger.debug(f'  - {out.name} -> {csv_targets}')
 
     group_found = False  # Flag to track if any group was found with ops.group_name
@@ -268,7 +268,7 @@ def update_table(ops, parent):
             index = int(group_suffix[-2])-1
             group_suffix = group_suffix[:-3]
             logger.debug(f'    - {group_suffix} index: {index}')
-        csv = out_to_csv_mapping.get(group_suffix)
+        out, csv = out_to_csv_mapping.get(group_suffix)
         if not csv:
             logger.warning(W_NOMATCHGRP+f'No output to handle `{group_name}` found')
             continue


### PR DESCRIPTION
This PR fixes incorrect mapping between output and CSV files for the Include Table preflight. Previously, the preflight parameters of the last provided output were used for all outputs, for example here `csv_testpoints_bottom` options were used for the `csv_testpoints_top` output.

```
  include_table:
    outputs: 
      - name: 'csv_testpoints_top'
        text_alignment: 'left'
        invert_columns_order: False
        border_width: 0.2
        header_rule_width: 0.2
        horizontal_rule_width: 0
        vertical_rule_width: 0
        top_rule_width: 0
      - name: 'csv_testpoints_bottom'
        text_alignment: 'right'
        invert_columns_order: True
        border_width: 0.2
        header_rule_width: 0.2
        horizontal_rule_width: 0
        vertical_rule_width: 0
        top_rule_width: 0
```