### PR TITLE
[Drill Output][Added] Option to omit generation of drill files

### DIFF
--- a/docs/source/configuration/outputs/ExcellonOptions.rst
+++ b/docs/source/configuration/outputs/ExcellonOptions.rst
@@ -4,6 +4,7 @@
 ExcellonOptions parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+-  **generate_drill_files** :index:`: <pair: output - excellon - options; generate_drill_files>` [:ref:`boolean <boolean>`] (default: ``true``) Generate drill files. Set to False and choose map format if only map is to be generated.
 -  **metric_units** :index:`: <pair: output - excellon - options; metric_units>` [:ref:`boolean <boolean>`] (default: ``true``) Use metric units instead of inches.
 -  **mirror_y_axis** :index:`: <pair: output - excellon - options; mirror_y_axis>` [:ref:`boolean <boolean>`] (default: ``false``) Invert the Y axis.
 -  **output** :index:`: <pair: output - excellon - options; output>` [:ref:`string <string>`] (default: ``'%f-%i%I%v.%x'``) name for the drill file, KiCad defaults if empty (%i='PTH_drill'). Affected by global options.

--- a/docs/source/configuration/outputs/Gerb_DrillOptions.rst
+++ b/docs/source/configuration/outputs/Gerb_DrillOptions.rst
@@ -5,6 +5,7 @@ Gerb_DrillOptions parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  **output** :index:`: <pair: output - gerb_drill - options; output>` [:ref:`string <string>`] (default: ``'%f-%i%I%v.%x'``) name for the drill file, KiCad defaults if empty (%i='PTH_drill'). Affected by global options.
+-  **generate_drill_files** :index:`: <pair: output - gerb_drill - options; generate_drill_files>` [:ref:`boolean <boolean>`] (default: ``true``) Generate drill files. Set to False and choose map format if only map is to be generated.
 -  ``dnf_filter`` :index:`: <pair: output - gerb_drill - options; dnf_filter>` [:ref:`string <string>` | :ref:`list(string) <list(string)>`] (default: ``'_null'``) Name of the filter to mark components as not fitted.
    A short-cut to use for simple cases where a variant is an overkill.
 

--- a/kibot/out_any_drill.py
+++ b/kibot/out_any_drill.py
@@ -42,6 +42,8 @@ class AnyDrill(VariantOptions):
     def __init__(self):
         # Options
         with document:
+            self.generate_drill_files = True
+            """ Generate drill files. Set to False and choose map format if only map is to be generated """
             self.use_aux_axis_as_origin = False
             """ Use the auxiliary axis as origin for coordinates """
             self.map = DrillMap
@@ -143,11 +145,12 @@ class AnyDrill(VariantOptions):
                 kicad_id_main += '-drl'
                 if not GS.ki8:
                     kicad_id_map = kicad_id_main
-            k_file = self.expand_filename(output_dir, '%f'+kicad_id_main+'.%x', '', self._ext)
-            file = ''
-            if self.output:
-                file = self.expand_filename(output_dir, self.output, kibot_id, self._ext)
-            filenames[k_file] = file
+            if self.generate_drill_files:
+                k_file = self.expand_filename(output_dir, '%f'+kicad_id_main+'.%x', '', self._ext)
+                file = ''
+                if self.output:
+                    file = self.expand_filename(output_dir, self.output, kibot_id, self._ext)
+                filenames[k_file] = file
             if self._map is not None:
                 k_file = self.expand_filename(output_dir, '%f'+kicad_id_map+'-drl_map.%x', '', self._map_ext)
                 file = ''
@@ -173,8 +176,7 @@ class AnyDrill(VariantOptions):
         if gen_map:
             drill_writer.SetMapFileFormat(self._map)
             logger.debug("Generating drill map type {} in {}".format(self._map, output_dir))
-        # We always generate the drill file
-        drill_writer.CreateDrillandMapFilesSet(output_dir, True, gen_map)
+        drill_writer.CreateDrillandMapFilesSet(output_dir, self.generate_drill_files, gen_map)
         # Rename the files
         files = self.get_file_names(output_dir)
         for k_f, f in files.items():

--- a/kibot/out_excellon.py
+++ b/kibot/out_excellon.py
@@ -18,6 +18,8 @@ class ExcellonOptions(AnyDrill):
     def __init__(self):
         super().__init__()
         with document:
+            self.generate_drill_files = True
+            """ Generate drill files. Set to False and choose map format if only map is to be generated """
             self.metric_units = True
             """ *Use metric units instead of inches """
             self.pth_and_npth_single_file = True


### PR DESCRIPTION
This PR adds the `generate_drill_files` option (default `True`) to the `gerb_drill` and `excellon` outputs. This is useful when one wants to only generate the drill map without drill files.