### PR TITLE
[Feature] Support OTF fonts installation in ressources

### DIFF
--- a/kibot/kiplot.py
+++ b/kibot/kiplot.py
@@ -1209,7 +1209,7 @@ def setup_fonts(source):
         return
     dest = os.path.expanduser('~/.fonts/')
     installed = False
-    for f in glob(os.path.join(source, '*.ttf')):
+    for f in glob(os.path.join(source, '*.[to][tf]f')):
         fname = os.path.basename(f)
         fdest = os.path.join(dest, fname)
         if os.path.isfile(fdest):


### PR DESCRIPTION
This PR adds OTF font installation support for fonts that should be automatically installed during a kibot run.