### PR TITLE
[Column List][Bom][Added] Added 'Net Label' column

### DIFF
--- a/kibot/bom/bom.py
+++ b/kibot/bom/bom.py
@@ -365,6 +365,7 @@ class ComponentGroup(object):
         if not self.fields[ColumnList.COL_DESCRIPTION_L]:
             self.fields[ColumnList.COL_DESCRIPTION_L] = comp.desc
         self.fields[ColumnList.COL_NET_NAME_L] = comp.net_name
+        self.fields[ColumnList.COL_NET_LABEL_L] = comp.net_name.split('/')[-1]
         self.fields[ColumnList.COL_NET_CLASS_L] = comp.net_class
         # KiCad attributes
         self.fields[ColumnList.COL_DNP_L] = self.solve_multiple_attributes('kicad_dnp', 'DNP')

--- a/kibot/bom/columnlist.py
+++ b/kibot/bom/columnlist.py
@@ -66,6 +66,8 @@ class ColumnList:
     COL_STATUS_L = COL_STATUS.lower()
     COL_NET_NAME = 'Net Name'
     COL_NET_NAME_L = COL_NET_NAME.lower()
+    COL_NET_LABEL = 'Net Label'
+    COL_NET_LABEL_L = COL_NET_LABEL.lower()
     COL_NET_CLASS = 'Net Class'
     COL_NET_CLASS_L = COL_NET_CLASS.lower()
     # KiCad attributes


### PR DESCRIPTION
This PR adds a new column `Net Label`, which is similar to to `Net Name` but without the path. Only displays the Net Label given in the schematic. For example, for the nets:

```
/Project Architecture/MCU - IOs/MOTOR_ENABLE
/Project Architecture/MCU - IOs/MOTOR_HIZ
/Project Architecture/MCU - IOs/MOTOR_FAULT
/Project Architecture/MCU - IOs/DRV_SCLK
/Project Architecture/MCU - IOs/DRV_MISO
```

Net label would be:

```
MOTOR_ENABLE
MOTOR_HIZ
MOTOR_FAULT
DRV_SCLK
DRV_MISO
```

If there is no '/', just keep it as is, for example:
+3V3 would stay +3V3

This is useful when creating simplified testpoint lists in a large hierarchical schematic, where the path can get very long.