### PR TITLE
Config: Panelize: Add missing fiducials plugin options

### DIFF
--- a/docs/samples/generic_plot.kibot.yaml
+++ b/docs/samples/generic_plot.kibot.yaml
@@ -2085,6 +2085,10 @@ outputs:
           extends: ''
           # [dict=null] Used to add fiducial marks to the (rail/frame of) the panel
           fiducials:
+            # [string=''] Argument to pass to the plugin. Used for *plugin*
+            arg: ''
+            # [string=''] Plugin specification (PACKAGE.FUNCTION or PYTHON_FILE.FUNCTION). Used for *plugin*
+            code: ''
             # `copper_size` is an alias for `coppersize`
             # [number|string=1] Diameter of the copper spot
             coppersize: 1

--- a/docs/source/configuration/outputs/PanelizeFiducials.rst
+++ b/docs/source/configuration/outputs/PanelizeFiducials.rst
@@ -5,6 +5,8 @@ PanelizeFiducials parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  **type** :index:`: <pair: output - panelize - options - configs - fiducials; type>` ''
+-  ``arg`` :index:`: <pair: output - panelize - options - configs - fiducials; arg>` [:ref:`string <string>`] (default: ``''``) Argument to pass to the plugin. Used for *plugin*.
+-  ``code`` :index:`: <pair: output - panelize - options - configs - fiducials; code>` [:ref:`string <string>`] (default: ``''``) Plugin specification (PACKAGE.FUNCTION or PYTHON_FILE.FUNCTION). Used for *plugin*.
 -  *copper_size* :index:`: <pair: output - panelize - options - configs - fiducials; copper_size>` Alias for coppersize.
 -  ``coppersize`` :index:`: <pair: output - panelize - options - configs - fiducials; coppersize>` [:ref:`number <number>` | :ref:`string <string>`] (default: ``1``) Diameter of the copper spot.
 -  ``hoffset`` :index:`: <pair: output - panelize - options - configs - fiducials; hoffset>` [:ref:`number <number>` | :ref:`string <string>`] (default: ``0``) Horizontal offset from panel edges.

--- a/kibot/out_panelize.py
+++ b/kibot/out_panelize.py
@@ -385,6 +385,10 @@ class PanelizeFiducials(PanelOptions):
             """ [number|string=1] Diameter of the solder mask opening """
             self.paste = False
             """ Include the fiducials in the paste layer (therefore they appear on the stencil) """
+            self.code = ''
+            """ Plugin specification (PACKAGE.FUNCTION or PYTHON_FILE.FUNCTION). Used for *plugin* """
+            self.arg = ''
+            """ Argument to pass to the plugin. Used for *plugin* """
         super().__init__()
 
     def config(self, parent):

--- a/tests/GUI/outputs
+++ b/tests/GUI/outputs
@@ -7021,6 +7021,20 @@
                     "DataTypeBoolean"
                   ],
                   null
+                ],
+                [
+                  "code",
+                  [
+                    "DataTypeString"
+                  ],
+                  null
+                ],
+                [
+                  "arg",
+                  [
+                    "DataTypeString"
+                  ],
+                  null
                 ]
               ]
             ],

--- a/tests/GUI/stats
+++ b/tests/GUI/stats
@@ -1,8 +1,8 @@
-48 outputs types with a total of 1874 different parameters
-Single type parameters: 1700 (91 %)
+48 outputs types with a total of 1876 different parameters
+Single type parameters: 1702 (91 %)
 Multi type parameters: 174 (9 %)
 Average parameters: 39
-Maximum number of parameters: 214
+Maximum number of parameters: 216
 Minimum number of parameters: 14
 Histogram:
   0-  9: 
@@ -75,7 +75,7 @@ Outputs sorted by parameters:
 - blender_export: 75
 - pcb_print: 89
 - bom: 145
-- panelize: 214
+- panelize: 216
 Average depth: 2.5416666666666665
 Maximum depth: 5
 Minimum depth: 2
@@ -137,7 +137,7 @@ Outputs sorted by depth:
 - bom: 5
 --------------------------------------------------------------------------------
 14 different data types
--             String:  843
+-             String:  845
 -            Boolean:  469
 -             Number:  266
 - ListStringSingular:  222
@@ -153,7 +153,7 @@ Outputs sorted by depth:
 -       NumberChoice:    1
 --------------------------------------------------------------------------------
 Used as single data type:
--             String:  689 
+-             String:  691 
 -            Boolean:  413 
 - ListStringSingular:  219 
 -             Number:  172 
@@ -390,11 +390,11 @@ Used as single data type:
 -              Number,String:   15 
 ================================================================================
 ================================================================================
-86 totals types with a total of 2242 different parameters
-Single type parameters: 2044 (91 %)
+86 totals types with a total of 2244 different parameters
+Single type parameters: 2046 (91 %)
 Multi type parameters: 198 (9 %)
 Average parameters: 26
-Maximum number of parameters: 214
+Maximum number of parameters: 216
 Minimum number of parameters: 1
 Histogram:
   0-  9: ***********************
@@ -505,7 +505,7 @@ Totals sorted by parameters:
 - blender_export: 75
 - pcb_print: 89
 - bom: 145
-- panelize: 214
+- panelize: 216
 Average depth: 2.186046511627907
 Maximum depth: 5
 Minimum depth: 1
@@ -605,7 +605,7 @@ Totals sorted by depth:
 - bom: 5
 --------------------------------------------------------------------------------
 14 different data types
--             String:  994
+-             String:  996
 -            Boolean:  567
 -             Number:  314
 - ListStringSingular:  251
@@ -621,7 +621,7 @@ Totals sorted by depth:
 -       NumberChoice:    1
 --------------------------------------------------------------------------------
 Used as single data type:
--             String:  824 
+-             String:  826 
 -            Boolean:  503 
 - ListStringSingular:  248 
 -             Number:  205 
@@ -648,4 +648,4 @@ Used as single data type:
 -                Dict,Number:    2 ['pcbdraw.options.margin', 'svg.options.margin']
 -             Boolean,Choice:    1 ['ibom.options.highlight_pin1']
 -          String,StringDict:    1 ['pcbdraw.options.remap']
-Found 2 unique warning/s (3 total)
+Found 3 unique warning/s (4 total)


### PR DESCRIPTION
Adds `code` and `arg` options to support plugin type for fiducials in panelization.
See relevant [KiKit documentation](https://yaqwsx.github.io/KiKit/latest/panelization/cli/#plugin_5) for reference