### PR TITLE
[PCB Draw Helpers][Fix] Wrong assertion for draw_poly

### DIFF
--- a/kibot/kicad/pcb_draw_helpers.py
+++ b/kibot/kicad/pcb_draw_helpers.py
@@ -81,7 +81,7 @@ def draw_text(g, x, y, text, h, w, layer, bold=False, alignment=GR_TEXT_HJUSTIFY
 
 
 def draw_poly(g, points, layer, filled=False, line_w=10000):
-    assert not points or len(points) < 3, "A polygon requires at least 3 points"
+    assert points or len(points) < 3, "A polygon requires at least 3 points"
     sps = pcbnew.SHAPE_POLY_SET()
     chain = pcbnew.SHAPE_LINE_CHAIN()
     for (x, y) in points:


### PR DESCRIPTION
This PR fixes a wrong assertion for the `draw_poly` function in `pcb_draw_helpers`