### PR TITLE
Use Kicad major version for 3dparty path

### DIFF
--- a/kibot/kicad/config.py
+++ b/kibot/kicad/config.py
@@ -319,7 +319,7 @@ class KiConf(object):
         home = os.environ.get('HOME')
         if home is None:
             return None
-        return os.path.join(home, '.local', 'share', 'kicad', '6.0', '3rdparty')
+        return os.path.join(home, '.local', 'share', 'kicad', str(GS.kicad_version_major)+'.0', '3rdparty')
 
     def load_ki5_env(cfg):
         """ Environment vars from KiCad 5 configuration """


### PR DESCRIPTION
I was running into an issue where kibot was looking for 3d models in the 6.0 directory, but this directory didn't exist.

I ran into the issue on your container: ghcr.io/inti-cmnb/kicad_auto_full:dev_k8_1.8.3-6506638_k8.0.6_d_sid_b3.5.1