### PR TITLE
[Fixed] Let frame_plotter create colors directory if needed

### DIFF
--- a/kibot/resources/tools/frame_plotter
+++ b/kibot/resources/tools/frame_plotter
@@ -26,6 +26,7 @@ pc = pcbnew.PLOT_CONTROLLER(board)
 # Yes, ridiculous, but the COLOR_SETTINGS class isn't exported
 sm = pcbnew.GetSettingsManager()
 path = os.path.join(pcbnew.SETTINGS_MANAGER.GetUserSettingsPath(), 'colors')
+os.makedirs(path, exist_ok=True)
 with tempfile.NamedTemporaryFile(mode='wt', delete=False, suffix='.json', prefix='kibo_color_', dir=path) as f:
     f.write(json.dumps({"board": {"worksheet": f"rgb({r}, {g}, {b})"}}))
 new_cs = sm.AddNewColorSettings(os.path.basename(f.name))


### PR DESCRIPTION
This prevents an issue where the frame_plotter command would fail if e.g. `~/.config/kicad/8.0/colors/` did not exist. In CI using ghcr.io/inti-cmnb/kicad8_auto_full this manifests as:

    ERROR:Running ['/usr/bin/python3', '/usr/share/kibot/tools/frame_plotter', '/tmp/tmp-kibot-pcb_print_tmp_pcb_for_frame-rcz7iz5p/PCB.kicad_pcb', '0.2823529411764706', '0.0', '0.0'] returned 1 (kibot.gs - gs.py:853)

Running the container manually and then running the above command shows the actual error messaged:

    Traceback (most recent call last):
      File "/usr/share/kibot/tools/frame_plotter", line 29, in <module> with tempfile.NamedTemporaryFile(mode='wt', delete=False, suffix='.json', prefix='kibo_color_', dir=path) as f:
    [...]

    FileNotFoundError: [Errno 2] No such file or directory: '/root/.config/kicad/8.0/colors/kibo_color_k0r3yvzc.json'

This commit fixes this by creating this directory if needed.