### PR TITLE
[Any Drill][Fixed] Do not overwrite other drill pairs with pth_id

### DIFF
--- a/kibot/out_any_drill.py
+++ b/kibot/out_any_drill.py
@@ -96,8 +96,11 @@ class AnyDrill(VariantOptions):
         if d[0] == 'N':
             # NPTH
             return self.npth_id if self.npth_id is not None else d+'_drill'
-        # PTH
-        return self.pth_id if self.pth_id is not None else d+'_drill'
+        elif d[0] == 'P':
+            # PTH
+            return self.pth_id if self.pth_id is not None else d+'_drill'
+        # Other drill pairs
+        return d+'_drill'
 
     @staticmethod
     def _get_layer_name(id):

--- a/tests/yaml_samples/drill.kibot.yaml
+++ b/tests/yaml_samples/drill.kibot.yaml
@@ -14,6 +14,8 @@ outputs:
       use_aux_axis_as_origin: false
       minimal_header: false
       mirror_y_axis: false
+      pth_id: PTH_drill
+      npth_id: NPTH_drill
       report: '%f-%i.%x'
       map: 'pdf'
 
@@ -23,4 +25,6 @@ outputs:
     dir: Drill
     options:
       use_aux_axis_as_origin: false
+      pth_id: PTH_drill
+      npth_id: NPTH_drill
       map: 'pdf'

--- a/tests/yaml_samples/drill.kibot.yaml
+++ b/tests/yaml_samples/drill.kibot.yaml
@@ -14,8 +14,6 @@ outputs:
       use_aux_axis_as_origin: false
       minimal_header: false
       mirror_y_axis: false
-      pth_id: PTH_drill
-      npth_id: NPTH_drill
       report: '%f-%i.%x'
       map: 'pdf'
 
@@ -25,6 +23,4 @@ outputs:
     dir: Drill
     options:
       use_aux_axis_as_origin: false
-      pth_id: PTH_drill
-      npth_id: NPTH_drill
       map: 'pdf'

--- a/tests/yaml_samples/drill_single.kibot.yaml
+++ b/tests/yaml_samples/drill_single.kibot.yaml
@@ -13,6 +13,7 @@ outputs:
       use_aux_axis_as_origin: false
       minimal_header: false
       mirror_y_axis: false
+      pth_id: drill
       report: '%f-%i.%x'
       map: 'pdf'
 
@@ -22,4 +23,6 @@ outputs:
     dir: Drill
     options:
       use_aux_axis_as_origin: false
+      pth_id: PTH_drill
+      npth_id: NPTH_drill
       map: 'pdf'


### PR DESCRIPTION
This PR fixes the overwriting of non through-hole drill pair files when `pth_id` is specified.
I've also modifed the YAML files for the test cases (non-legacy) so that the default `pth_id` and `npth_id` are explicitly specified. Without the fix, it will overwrite the files which results in the test failing.
I'm not sure how to modify the legacy YAML files for this test, I've tried to add `pth_id` and `npth_id` but doesn't seem to change anything, I assume the legacy way of generating drill files did not have a function to rename the files? In this case it would be a non-issue