### PR TITLE
[Drill][Added] CSV Drill Table output

### DIFF
--- a/kibot/kicad/drill_info.py
+++ b/kibot/kicad/drill_info.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Nguyen Vincent
+# Copyright (c) 2024 Salvador E. Tropea
+# Copyright (c) 2024 Instituto Nacional de Tecnología Industrial
+# License: AGPL-3.0
+# Project: KiBot (formerly KiPlot)
+# Contributed by Nguyen Vincent (@nguyen-v)
+# Reimplementation of
+# https://gitlab.com/kicad/code/kicad/-/blob/master/pcbnew/exporters/gendrill_file_writer_base.cpp
+from ..gs import GS
+import pcbnew
+from kibot.misc import VIATYPE_THROUGH
+from kibot import log
+
+logger = log.get_logger()
+
+PLATED_DICT = {True: 'NPTH',
+               False: 'PTH'}
+
+HOLE_SHAPE_DICT = {0: 'Round',
+                   1: 'Slot',
+                   2: 'Round + Slot'}
+
+if not GS.ki5:
+    HOLE_TYPE_DICT = {pcbnew.HOLE_ATTRIBUTE_HOLE_MECHANICAL: 'Mechanical',
+                      pcbnew.HOLE_ATTRIBUTE_HOLE_PAD: 'Pad',
+                      pcbnew.HOLE_ATTRIBUTE_HOLE_VIA_THROUGH: 'Via',
+                      pcbnew.HOLE_ATTRIBUTE_HOLE_VIA_BURIED: 'Via'}
+
+
+def get_unique_layer_pairs():
+    # Collect all vias on the board
+    vias = [item for item in GS.board.GetTracks() if isinstance(item, pcbnew.PCB_VIA)]
+
+    # Use a set to store unique layer pairs
+    unique_layer_pairs = set()
+
+    for via in vias:
+        # Extract layer pairs from the via
+        start_layer = via.TopLayer()
+        end_layer = via.BottomLayer()
+
+        layer_pair = (start_layer, end_layer)
+
+        via_type = via.GetViaType()
+
+        # Only note blind or buried vias (not through-hole vias)
+        if via_type != VIATYPE_THROUGH:
+            unique_layer_pairs.add(layer_pair)
+
+    # Start the returned list with the default through-hole layer pair
+    layer_pairs = [(pcbnew.F_Cu, pcbnew.B_Cu)]
+
+    # Add each unique layer pair individually to the list
+    for layer_pair in unique_layer_pairs:
+        layer_pairs.append(layer_pair)
+
+    return layer_pairs
+
+
+def get_num_layer_pairs(merge_PTH_NPTH=True):
+
+    hole_sets = get_unique_layer_pairs()
+
+    if not merge_PTH_NPTH:
+
+        hole_sets.append((pcbnew.F_Cu, pcbnew.B_Cu))
+
+        hole_list_layer_pair, _ = build_holes_list(
+            hole_sets[-1], merge_PTH_NPTH, generate_NPTH_list=True, group_slots_and_round_holes=True
+        )
+        if len(hole_list_layer_pair) == 0:
+            hole_sets.pop()
+
+    return len(hole_sets)
+
+
+def get_full_holes_list(merge_PTH_NPTH=True, group_slots_and_round_holes=True):
+
+    hole_list = []
+    tool_list = []
+
+    hole_sets = get_unique_layer_pairs()
+
+    if not merge_PTH_NPTH:
+        hole_sets.append((pcbnew.F_Cu, pcbnew.B_Cu))
+
+    for i, pair in enumerate(hole_sets):
+        doing_npth = not merge_PTH_NPTH and (i == len(hole_sets)-1)
+
+        hole_list_layer_pair, tool_list_layer_pair = build_holes_list(pair, merge_PTH_NPTH, doing_npth,
+                                                                      group_slots_and_round_holes)
+
+        if len(hole_list_layer_pair) > 0:
+            hole_list.append(hole_list_layer_pair)
+            tool_list.append(tool_list_layer_pair)
+        elif doing_npth:
+            doing_npth = False
+            hole_sets.pop()
+
+    return hole_list, tool_list, hole_sets, doing_npth
+
+
+def get_layer_pair_name(index, use_layer_names=False, merge_PTH_NPTH=True, group_slots_and_round_holes=True):
+    hole_sets = get_unique_layer_pairs()
+
+    if not merge_PTH_NPTH:
+
+        hole_sets.append((pcbnew.F_Cu, pcbnew.B_Cu))
+
+        hole_list_layer_pair, _ = build_holes_list(
+            hole_sets[-1], merge_PTH_NPTH, generate_NPTH_list=True, group_slots_and_round_holes=True
+        )
+        if len(hole_list_layer_pair) == 0:
+            hole_sets.pop()
+
+    if index > len(hole_sets)-1:
+        logger.error(f"Layer pair index {index} out of range ({len(hole_sets)})")
+
+    layer_pair = hole_sets[index]
+
+    if use_layer_names:
+        return f'{GS.board.GetLayerName(layer_pair[0])} - {GS.board.GetLayerName(layer_pair[1])}'
+    else:
+        layer_cnt = GS.board.GetCopperLayerCount()
+        top_layer = layer_pair[0] + 1
+        bot_layer = layer_pair[1] + 1 if layer_pair[1] != pcbnew.B_Cu else layer_cnt
+        return f'L{top_layer} - L{bot_layer}'
+
+
+def build_holes_list(layer_pair, merge_PTH_NPTH, generate_NPTH_list=True,
+                     group_slots_and_round_holes=True):
+
+    # Buffer associated to specific layer pairs
+    hole_list_layer_pair = []
+    tool_list_layer_pair = []
+
+    assert layer_pair[0] < layer_pair[1], "Invalid layer pair order."
+
+    # Add plated vias to hole_list_layer_pair
+    if not generate_NPTH_list:
+        for via in GS.board.GetTracks():
+            # Check if the current track is a via
+            if not isinstance(via, pcbnew.PCB_VIA):
+                continue
+
+            hole_sz = via.GetDrillValue()
+
+            if hole_sz == 0:
+                continue
+
+            new_hole = pcbnew.HOLE_INFO()
+            new_hole.m_ItemParent = via
+
+            if GS.ki5:
+                new_hole.m_HoleAttribute = 0
+            else:
+                if layer_pair == (pcbnew.F_Cu, pcbnew.B_Cu):
+                    new_hole.m_HoleAttribute = pcbnew.HOLE_ATTRIBUTE_HOLE_VIA_THROUGH
+                else:
+                    new_hole.m_HoleAttribute = pcbnew.HOLE_ATTRIBUTE_HOLE_VIA_BURIED
+
+            new_hole.m_Tool_Reference = -1
+            new_hole.m_Hole_Orient = GS.angle(0)
+            new_hole.m_Hole_Diameter = hole_sz
+            new_hole.m_Hole_NotPlated = False
+            new_hole.m_Hole_Size.x = new_hole.m_Hole_Size.y = new_hole.m_Hole_Diameter
+
+            new_hole.m_Hole_Shape = 0
+            new_hole.m_Hole_Pos = via.GetStart()
+
+            new_hole.m_Hole_Top_Layer = via.TopLayer()
+            new_hole.m_Hole_Bottom_Layer = via.BottomLayer()
+
+            if (new_hole.m_Hole_Top_Layer != layer_pair[0]) or \
+               (new_hole.m_Hole_Bottom_Layer != layer_pair[1]):
+                continue
+
+            hole_list_layer_pair.append(new_hole)
+
+    # Add footprint/pad related PTH to hole_list_layer_pair
+    if layer_pair == (pcbnew.F_Cu, pcbnew.B_Cu):
+        for footprint in GS.board.GetFootprints():
+            for pad in footprint.Pads():
+
+                if not merge_PTH_NPTH:
+                    if not generate_NPTH_list and pad.GetAttribute() == pcbnew.PAD_ATTRIB_NPTH:
+                        continue
+
+                    if generate_NPTH_list and pad.GetAttribute() != pcbnew.PAD_ATTRIB_NPTH:
+                        continue
+
+                if pad.GetDrillSize().x == 0:
+                    continue
+
+                new_hole = pcbnew.HOLE_INFO()
+
+                new_hole.m_ItemParent = pad
+                new_hole.m_Hole_NotPlated = pad.GetAttribute() == pcbnew.PAD_ATTRIB_NPTH
+                if GS.ki5:
+                    new_hole.m_HoleAttribute = 0
+                else:
+                    new_hole.m_HoleAttribute = (pcbnew.HOLE_ATTRIBUTE_HOLE_MECHANICAL if
+                                                new_hole.m_Hole_NotPlated else pcbnew.HOLE_ATTRIBUTE_HOLE_PAD)
+                new_hole.m_Tool_Reference = -1
+                new_hole.m_Hole_Orient = pad.GetOrientation()
+                new_hole.m_Hole_Diameter = min(pad.GetDrillSize().x, pad.GetDrillSize().y)
+                new_hole.m_Hole_Size = pad.GetDrillSize()
+                new_hole.m_Hole_Shape = 1 if (pad.GetDrillShape() != pcbnew.PAD_DRILL_SHAPE_CIRCLE and
+                                              pad.GetDrillSize().x != pad.GetDrillSize().y) else 0
+                new_hole.m_Hole_Pos = pad.GetPosition()
+                new_hole.m_Hole_Top_Layer = pcbnew.F_Cu
+                new_hole.m_Hole_Bottom_Layer = pcbnew.B_Cu
+
+                hole_list_layer_pair.append(new_hole)
+
+    if GS.ki5:
+        hole_list_layer_pair.sort(key=lambda hole: (
+            hole.m_Hole_NotPlated,       # Non-plated holes come after plated holes
+            hole.m_Hole_Diameter,        # Increasing diameter
+            hole.m_Hole_Shape,           # Circles first, then slots
+            hole.m_Hole_Pos.x,           # X position
+            hole.m_Hole_Pos.y            # Y position
+        ))
+    else:
+        hole_list_layer_pair.sort(key=lambda hole: (
+            hole.m_Hole_NotPlated,       # Non-plated holes come after plated holes
+            hole.m_Hole_Diameter,        # Increasing diameter
+            hole.m_HoleAttribute,        # Attribute type
+            hole.m_Hole_Shape,           # Circles first, then slots
+            hole.m_Hole_Pos.x,           # X position
+            hole.m_Hole_Pos.y            # Y position
+        ))
+
+    last_hole_diameter = -1
+    last_not_plated = False
+    if GS.ki5:
+        last_attribute = 0
+    else:
+        last_attribute = pcbnew.HOLE_ATTRIBUTE_HOLE_UNKNOWN
+
+    last_hole_shape = -1
+
+    for hole in hole_list_layer_pair:
+
+        if (hole.m_Hole_Diameter != last_hole_diameter or
+                hole.m_Hole_NotPlated != last_not_plated or
+                hole.m_HoleAttribute != last_attribute or
+                (not group_slots_and_round_holes and hole.m_Hole_Shape != last_hole_shape)):
+
+            new_tool = pcbnew.DRILL_TOOL(0, False)
+
+            new_tool.m_Diameter = hole.m_Hole_Diameter
+            new_tool.m_Hole_NotPlated = hole.m_Hole_NotPlated
+            if not GS.ki5:
+                new_tool.m_HoleAttribute = hole.m_HoleAttribute
+            new_tool.m_Hole_Shape = hole.m_Hole_Shape  # not present in original implementation
+            new_tool.m_TotalCount = 0
+            new_tool.m_OvalCount = 0
+
+            tool_list_layer_pair.append(new_tool)
+
+            last_hole_diameter = new_tool.m_Diameter
+            last_not_plated = new_tool.m_Hole_NotPlated
+            if not GS.ki5:
+                last_attribute = new_tool.m_HoleAttribute
+            last_hole_shape = new_tool.m_Hole_Shape
+
+        tool_index = len(tool_list_layer_pair)
+
+        if tool_index == 0:
+            continue
+
+        hole.m_Tool_Reference = tool_index
+        tool_list_layer_pair[-1].m_TotalCount += 1
+
+        if hole.m_Hole_Shape:
+            tool_list_layer_pair[-1].m_OvalCount += 1
+
+        if (tool_list_layer_pair[-1].m_OvalCount > 0 and
+                tool_list_layer_pair[-1].m_TotalCount > tool_list_layer_pair[-1].m_OvalCount):
+            tool_list_layer_pair[-1].m_Hole_Shape = 2  # The tool is associated to both slots and round holes
+
+    return hole_list_layer_pair, tool_list_layer_pair

--- a/kibot/kicad/drill_info.py
+++ b/kibot/kicad/drill_info.py
@@ -190,8 +190,7 @@ def build_holes_list(layer_pair, merge_PTH_NPTH, generate_NPTH_list=True,
 
     # Add footprint/pad related PTH to hole_list_layer_pair
     if layer_pair == (pcbnew.F_Cu, pcbnew.B_Cu):
-        footprints = GS.board.GetModules() if GS.ki5 else GS.board.GetFootprints()
-        for footprint in footprints:
+        for footprint in GS.get_modules():
             for pad in footprint.Pads():
 
                 if not merge_PTH_NPTH:

--- a/kibot/kicad/drill_info.py
+++ b/kibot/kicad/drill_info.py
@@ -30,7 +30,10 @@ if not GS.ki5:
 
 def get_unique_layer_pairs():
     # Collect all vias on the board
-    vias = [item for item in GS.board.GetTracks() if isinstance(item, pcbnew.PCB_VIA)]
+    via_type_key = 'VIA' if GS.ki5 else 'PCB_VIA'
+
+    # Collect all vias on the board
+    vias = [item for item in GS.board.GetTracks() if item.GetClass() == via_type_key]
 
     # Use a set to store unique layer pairs
     unique_layer_pairs = set()
@@ -140,9 +143,12 @@ def build_holes_list(layer_pair, merge_PTH_NPTH, generate_NPTH_list=True,
     # Add plated vias to hole_list_layer_pair
     if not generate_NPTH_list:
         for via in GS.board.GetTracks():
-            # Check if the current track is a via
-            if not isinstance(via, pcbnew.PCB_VIA):
-                continue
+            if GS.ki5:
+                if via.GetClass() != 'VIA':
+                    continue
+            else:
+                if not isinstance(via, pcbnew.PCB_VIA):
+                    continue
 
             hole_sz = via.GetDrillValue()
 

--- a/kibot/kicad/drill_info.py
+++ b/kibot/kicad/drill_info.py
@@ -191,10 +191,10 @@ def build_holes_list(layer_pair, merge_PTH_NPTH, generate_NPTH_list=True,
             for pad in footprint.Pads():
 
                 if not merge_PTH_NPTH:
-                    if not generate_NPTH_list and pad.GetAttribute() == pcbnew.PAD_ATTRIB_NPTH:
+                    if not generate_NPTH_list and pad.GetAttribute() == (3 if GS.ki5 else pcbnew.PAD_ATTRIB_NPTH):
                         continue
 
-                    if generate_NPTH_list and pad.GetAttribute() != pcbnew.PAD_ATTRIB_NPTH:
+                    if generate_NPTH_list and pad.GetAttribute() != (3 if GS.ki5 else pcbnew.PAD_ATTRIB_NPTH):
                         continue
 
                 if pad.GetDrillSize().x == 0:
@@ -203,7 +203,7 @@ def build_holes_list(layer_pair, merge_PTH_NPTH, generate_NPTH_list=True,
                 new_hole = pcbnew.HOLE_INFO()
 
                 new_hole.m_ItemParent = pad
-                new_hole.m_Hole_NotPlated = pad.GetAttribute() == pcbnew.PAD_ATTRIB_NPTH
+                new_hole.m_Hole_NotPlated = pad.GetAttribute() == (3 if GS.ki5 else pcbnew.PAD_ATTRIB_NPTH)
                 if GS.ki5:
                     new_hole.m_HoleAttribute = 0
                 else:

--- a/kibot/kicad/drill_info.py
+++ b/kibot/kicad/drill_info.py
@@ -130,8 +130,8 @@ def get_layer_pair_name(index, use_layer_names=False, merge_PTH_NPTH=True, group
             top_layer = layer_pair[0] + 1
             bot_layer = layer_pair[1] + 1 if layer_pair[1] != pcbnew.B_Cu else layer_cnt
         else:
-            top_layer = 1 if layer_pair[0] == pcbnew.F_Cu else layer_pair[0]/2 - 1
-            bot_layer = layer_cnt if layer_pair[1] == pcbnew.B_Cu else layer_pair[1]/2 - 1
+            top_layer = 1 if layer_pair[0] == pcbnew.F_Cu else layer_pair[0]/2
+            bot_layer = layer_cnt if layer_pair[1] == pcbnew.B_Cu else layer_pair[1]/2
         return f'L{top_layer} - L{bot_layer}'
 
 

--- a/kibot/kicad/drill_info.py
+++ b/kibot/kicad/drill_info.py
@@ -186,7 +186,8 @@ def build_holes_list(layer_pair, merge_PTH_NPTH, generate_NPTH_list=True,
 
     # Add footprint/pad related PTH to hole_list_layer_pair
     if layer_pair == (pcbnew.F_Cu, pcbnew.B_Cu):
-        for footprint in GS.board.GetFootprints():
+        footprints = GS.board.GetModules() if GS.ki5 else GS.board.GetFootprints()
+        for footprint in footprints:
             for pad in footprint.Pads():
 
                 if not merge_PTH_NPTH:

--- a/kibot/kicad/drill_info.py
+++ b/kibot/kicad/drill_info.py
@@ -126,8 +126,12 @@ def get_layer_pair_name(index, use_layer_names=False, merge_PTH_NPTH=True, group
         return f'{GS.board.GetLayerName(layer_pair[0])} - {GS.board.GetLayerName(layer_pair[1])}'
     else:
         layer_cnt = GS.board.GetCopperLayerCount()
-        top_layer = layer_pair[0] + 1
-        bot_layer = layer_pair[1] + 1 if layer_pair[1] != pcbnew.B_Cu else layer_cnt
+        if not GS.ki9:
+            top_layer = layer_pair[0] + 1
+            bot_layer = layer_pair[1] + 1 if layer_pair[1] != pcbnew.B_Cu else layer_cnt
+        else:
+            top_layer = 1 if layer_pair[0] == pcbnew.F_Cu else layer_pair[0]/2 - 1
+            bot_layer = layer_cnt if layer_pair[1] == pcbnew.B_Cu else layer_pair[1]/2 - 1
         return f'L{top_layer} - L{bot_layer}'
 
 

--- a/kibot/out_any_drill.py
+++ b/kibot/out_any_drill.py
@@ -153,7 +153,6 @@ class AnyDrill(VariantOptions):
             if hasattr(self, 'pth_and_npth_single_file') and self.table.unify_pth_and_npth == 'auto':
                 self._table_unify_pth_and_npth = self.pth_and_npth_single_file
             else:
-                logger.debug(f"unify {self.table.unify_pth_and_npth}")
                 if self.table.unify_pth_and_npth in ["no", "auto"]:
                     self._table_unify_pth_and_npth = False
                 else:

--- a/kibot/out_any_drill.py
+++ b/kibot/out_any_drill.py
@@ -5,8 +5,10 @@
 # Project: KiBot (formerly KiPlot)
 import os
 import re
+import csv
 from pcbnew import (PLOT_FORMAT_HPGL, PLOT_FORMAT_POST, PLOT_FORMAT_GERBER, PLOT_FORMAT_DXF, PLOT_FORMAT_SVG,
-                    PLOT_FORMAT_PDF, wxPoint)
+                    PLOT_FORMAT_PDF, wxPoint, B_Cu)
+from .kicad.drill_info import get_full_holes_list, PLATED_DICT, HOLE_SHAPE_DICT
 from .optionable import Optionable
 from .out_base import VariantOptions
 from .gs import GS
@@ -15,7 +17,28 @@ from .misc import W_NODRILL
 from .macros import macros, document  # noqa: F401
 from . import log
 
+if not GS.ki5:
+    from .kicad.drill_info import HOLE_TYPE_DICT
+
 logger = log.get_logger()
+
+if GS.ki5:
+    VALID_COLUMNS = [
+        "Count",
+        "Hole Size",
+        "Plated",
+        "Hole Shape",
+        "Drill Layer Pair",
+    ]
+else:
+    VALID_COLUMNS = [
+        "Count",
+        "Hole Size",
+        "Plated",
+        "Hole Shape",
+        "Drill Layer Pair",
+        "Hole Type",
+    ]
 
 
 class DrillMap(Optionable):
@@ -39,6 +62,32 @@ class DrillReport(Optionable):
         self._unknown_is_error = True
 
 
+class DrillOptions(Optionable):
+    def __init__(self):
+        super().__init__()
+        with document:
+            self.pth_and_npth_single_file = True
+            """ Generate one file for both, plated holes and non-plated holes, instead of two separated files """
+            self.group_slots_and_round_holes = True
+            """ By default KiCad groups slots and rounded holes if they can be cut from the same tool (same diameter) """
+        self._unknown_is_error = True
+
+
+class DrillTable(DrillOptions):
+    def __init__(self):
+        super().__init__()
+        with document:
+            self.output = GS.def_global_output
+            """ *Name of the drill table. Not generated unless a name is specified.
+                (%i='drill_table' %x='csv') """
+            self.units = 'millimeters_mils'
+            """ *[millimeters,mils,millimeters_mils,mils_millimeters] Units used for the hole sizes """
+            self.columns = []
+            """ *[list(dict)|list(string)=?] List of columns to display.
+                Each entry can be a dictionary with `field`, `name` or just a string (field name).
+                Default fields are: ["Count", "Hole Size", "Plated", "Hole Shape", "Drill Layer Pair", "Hole Type"] """
+
+
 class AnyDrill(VariantOptions):
     def __init__(self):
         # Options
@@ -54,6 +103,8 @@ class AnyDrill(VariantOptions):
             """ *name for the drill file, KiCad defaults if empty (%i='PTH_drill') """
             self.report = DrillReport
             """ [dict|string=''] Name of the drill report. Not generated unless a name is specified """
+            self.table = DrillTable
+            """ [dict|string=''] Name of the drill table. Not generated unless a name is specified """
             self.pth_id = None
             """ [string] Force this replacement for %i when generating PTH and unified files """
             self.npth_id = None
@@ -86,6 +137,17 @@ class AnyDrill(VariantOptions):
         self._map = self._map_map[map]
         # Solve the report for both cases
         self._report = self.report.filename if isinstance(self.report, DrillReport) else self.report
+        # Solve the table for both cases
+        if isinstance(self.table, str):
+            self._table_output = self.table
+            self._table_pth_npth_single_file = True
+            self._table_group_slots_and_round_holes = True
+            self._table_units = 'millimeters_mils'
+        else:
+            self._table_output = self.table.output
+            self._table_pth_npth_single_file = self.table.pth_and_npth_single_file
+            self._table_group_slots_and_round_holes = self.table.group_slots_and_round_holes
+            self._table_units = self.table.units
         self._expand_id = 'drill'
         self._expand_ext = self._ext
 
@@ -117,6 +179,13 @@ class AnyDrill(VariantOptions):
         return 'in'+m.group(1)
 
     @staticmethod
+    def _get_layer_pair_names(layer_pair):
+        layer_cnt = GS.board.GetCopperLayerCount()
+        top_layer = layer_pair[0] + 1
+        bot_layer = layer_pair[1] + 1 if layer_pair[1] != B_Cu else layer_cnt
+        return f"(L{top_layer} - L{bot_layer})"
+
+    @staticmethod
     def _get_drill_groups(unified):
         """ Get the ID for all the generated files.
             It includes buried/blind vias. """
@@ -134,6 +203,59 @@ class AnyDrill(VariantOptions):
                     pairs.add(pair)
         groups.extend(list(pairs))
         return groups
+
+    def get_columns_config(self):
+        """Process the columns configuration."""
+        columns = self.table.columns if isinstance(self.table, DrillTable) else []
+        if not columns:
+            # Default column configuration based on VALID_COLUMNS
+            return [{"field": col, "name": col} for col in VALID_COLUMNS]
+
+        # Process custom columns
+        processed_columns = []
+        for col in columns:
+            if isinstance(col, str):
+                # Simple field name
+                processed_columns.append({"field": col, "name": col})
+            elif isinstance(col, dict):
+                # Detailed configuration
+                processed_columns.append({
+                    "field": col.get("field", ""),
+                    "name": col.get("name", col.get("field", "")),
+                })
+        return processed_columns
+
+    def validate_and_process_columns(self, cols, valid_columns):
+
+        processed_columns = []
+        valid_columns_l = {col.lower(): col for col in valid_columns}
+
+        for col in cols:
+            if isinstance(col, str):
+                # Simple field name
+                field = col
+                name = col
+            elif isinstance(col, dict):
+                # Detailed configuration
+                field = col.get("field", "")
+                name = col.get("name", field)
+            else:
+                logger.warning(f"Invalid column entry: {col}")
+
+            field_lower = field.lower()
+            if field_lower not in valid_columns_l:
+                logger.warning(f"Invalid column name `{field}`. Valid columns are: {list(valid_columns_l.values())}")
+                continue  # Skip invalid columns
+
+            processed_columns.append({
+                "field": valid_columns_l[field_lower],  # Use the original case from the valid columns list
+                "name": name,
+            })
+
+        if not processed_columns:
+            logger.error("No valid columns specified. At least one valid column is required.")
+
+        return processed_columns
 
     def get_file_names(self, output_dir):
         """ Returns a dict containing KiCad names and its replacement.
@@ -180,8 +302,13 @@ class AnyDrill(VariantOptions):
         if gen_map:
             drill_writer.SetMapFileFormat(self._map)
             logger.debug("Generating drill map type {} in {}".format(self._map, output_dir))
-        if not self.generate_drill_files and not gen_map and not self._report:
-            logger.warning(W_NODRILL+f"Not generating drill files nor drill maps nor report on `{self._parent.name}`")
+        if not self.generate_drill_files and not gen_map and not self._report and not self._table_output:
+            logger.warning(
+                W_NODRILL +
+                "Not generating drill files nor drill maps "
+                "nor report nor drill table on "
+                f"`{self._parent.name}`"
+            )
         drill_writer.CreateDrillandMapFilesSet(output_dir, self.generate_drill_files, gen_map)
         # Rename the files
         files = self.get_file_names(output_dir)
@@ -194,6 +321,73 @@ class AnyDrill(VariantOptions):
             drill_report_file = self.expand_filename(output_dir, self._report, 'drill_report', 'txt')
             logger.debug("Generating drill report: "+drill_report_file)
             drill_writer.GenDrillReportFile(drill_report_file)
+        # Generate the drill table
+        if self._table_output:
+
+            hole_list, tool_list, hole_sets, npth = get_full_holes_list(self._table_pth_npth_single_file,
+                                                                        self._table_group_slots_and_round_holes)
+
+            # Get column configuration
+
+            columns = self.get_columns_config()
+            columns = self.validate_and_process_columns(columns, VALID_COLUMNS)
+
+            for i, (tools, layer_pair) in enumerate(zip(tool_list, hole_sets)):
+
+                layer_pair_name = AnyDrill._get_layer_pair_names(layer_pair)
+
+                if npth and i == len(hole_sets)-1:
+                    layer_pair_name += '_NPTH'
+
+                csv_file = self.expand_filename(output_dir, self._table_output, f'{layer_pair_name}' + '_drill_table', 'csv')
+
+                logger.debug("Generating drill table: "+csv_file)
+
+                with open(csv_file, mode='w', newline='', encoding='utf-8') as file:
+                    writer = csv.writer(file)
+
+                    # Write header
+                    writer.writerow([col["name"] for col in columns])
+
+                    # Write rows
+                    for tool in tools:
+                        row = []
+                        for col in columns:
+                            if col["field"] == "Count":
+                                value = (f'{tool.m_TotalCount-tool.m_OvalCount} + {tool.m_OvalCount}' if
+                                         tool.m_Hole_Shape == 2 else tool.m_TotalCount)
+                            elif col["field"] == "Hole Size":
+                                if self._table_units == 'millimeters':
+                                    value = f'{GS.to_mm(tool.m_Diameter):.2f}mm'
+                                elif self._table_units == 'mils':
+                                    value = f'{GS.to_mils(tool.m_Diameter):.2f}mils'
+                                elif self._table_units == 'mils_millimeters':
+                                    value = f'{GS.to_mils(tool.m_Diameter):.2f}mils ({GS.to_mm(tool.m_Diameter):.2f}mm)'
+                                else:
+                                    value = f'{GS.to_mm(tool.m_Diameter):.2f}mm ({GS.to_mils(tool.m_Diameter):.2f}mils)'
+                            elif col["field"] == "Plated":
+                                value = PLATED_DICT[tool.m_Hole_NotPlated]
+                            elif col["field"] == "Hole Shape":
+                                value = HOLE_SHAPE_DICT[tool.m_Hole_Shape]
+                            elif col["field"] == "Drill Layer Pair":
+                                value = f'{GS.board.GetLayerName(layer_pair[0])} - {GS.board.GetLayerName(layer_pair[1])}'
+                            elif col["field"] == "Hole Type":
+                                if not GS.ki5:
+                                    value = HOLE_TYPE_DICT[tool.m_HoleAttribute]
+                            else:
+                                value = ""
+                            row.append(value)
+                        writer.writerow(row)
+
+                    row = []
+                    for col in columns:
+                        if col["field"] == "Count":
+                            value = f"Total {sum(tool.m_TotalCount for tool in tools)}"
+                        else:
+                            value = ""
+                        row.append(value)
+                    writer.writerow(row)
+
         self.unfilter_pcb_components()
 
     def get_targets(self, out_dir):
@@ -203,4 +397,13 @@ class AnyDrill(VariantOptions):
             targets.append(f if f else k_f)
         if self._report:
             targets.append(self.expand_filename(out_dir, self._report, 'drill_report', 'txt'))
+        if self._table_output:
+            _, _, hole_sets, npth = get_full_holes_list(self._table_pth_npth_single_file,
+                                                        self._table_group_slots_and_round_holes)
+            for i, layer_pair in enumerate(hole_sets):
+                layer_pair_name = AnyDrill._get_layer_pair_names(layer_pair)
+                if npth and i == len(hole_sets)-1:
+                    layer_pair_name += '_NPTH'
+                targets.append(self.expand_filename(out_dir, self._table_output,
+                               f'{layer_pair_name}' + '_drill_table', 'csv'))
         return targets

--- a/tests/board_samples/kicad_5/3Rs_bv.kicad_pcb
+++ b/tests/board_samples/kicad_5/3Rs_bv.kicad_pcb
@@ -231,5 +231,6 @@
   (via blind (at 119.25 37.75) (size 0.8) (drill 0.4) (layers F.Cu In1.Cu) (net 0))
   (via blind (at 120.75 36.25) (size 0.8) (drill 0.4) (layers In1.Cu In2.Cu) (net 0))
   (via blind (at 119.25 34.5) (size 0.8) (drill 0.4) (layers In2.Cu B.Cu) (net 0))
-
+  (via (at 117 34) (size 0.8) (drill 0.4) (layers F.Cu B.Cu) (net 0))
+  
 )

--- a/tests/test_plot/test_drill.py
+++ b/tests/test_plot/test_drill.py
@@ -12,7 +12,6 @@ pytest-3 --log-cli-level debug
 
 import os
 import sys
-import logging
 from . import context
 
 DRILL_DIR = 'Drill'
@@ -110,7 +109,6 @@ def do_3Rs(test_dir, conf, modern, single=False):
     ctx.expect_gerber_has_apertures(npth_gbr_drl, ['C,2.100000'])
     # Verify the generated drill tables
     rows_pth, header_pth, _ = ctx.load_csv(pth_csv_drl.replace(DRILL_DIR+'/', ''))
-    logging.debug(f"rows pth {rows_pth}")
     rows_npth, header_npth, _ = ctx.load_csv(npth_csv_drl.replace(DRILL_DIR+'/', ''))
     rows_f1, header_f1, _ = ctx.load_csv(f1_csv_drl.replace(DRILL_DIR+'/', ''))
     rows_12, header_12, _ = ctx.load_csv(i12_csv_drl.replace(DRILL_DIR+'/', ''))

--- a/tests/test_plot/test_drill.py
+++ b/tests/test_plot/test_drill.py
@@ -12,10 +12,26 @@ pytest-3 --log-cli-level debug
 
 import os
 import sys
+import logging
 from . import context
 
 DRILL_DIR = 'Drill'
 positions = {'R1': (105, 35, 'top'), 'R2': (110, 35, 'bottom'), 'R3': (110, 45, 'top')}
+
+DRILL_TABLE_HEADER = ['Count', 'Hole Size', 'Plated', 'Hole Shape', 'Drill Layer Pair', 'Hole Type']
+ROWS_PTH = [['1', '0.40mm (15.75mils)', 'PTH', 'Round', 'F.Cu - B.Cu', 'Via'],
+            ['2', '1.00mm (39.37mils)', 'PTH', 'Round', 'F.Cu - B.Cu', 'Pad'],
+            ['Total 3', '', '', '', '', '']]
+ROWS_NPTH = [['1', '2.10mm (82.68mils)', 'NPTH', 'Round', 'F.Cu - B.Cu', 'Mechanical'],
+             ['Total 1', '', '', '', '', '']]
+ROWS_PTH_NPTH = [['1', '0.40mm (15.75mils)', 'PTH', 'Round', 'F.Cu - B.Cu', 'Via'],
+                 ['2', '1.00mm (39.37mils)', 'PTH', 'Round', 'F.Cu - B.Cu', 'Pad'],
+                 ['1', '2.10mm (82.68mils)', 'NPTH', 'Round', 'F.Cu - B.Cu', 'Mechanical'],
+                 ['Total 4', '', '', '', '', '']]
+ROWS_F1 = [['1', '0.40mm (15.75mils)', 'PTH', 'Round', 'F.Cu - El1', 'Via'],
+           ['Total 1', '', '', '', '', '']]
+ROWS_12 = [['1', '0.40mm (15.75mils)', 'PTH', 'Round', 'El1 - In2.Cu', 'Via'],
+           ['Total 1', '', '', '', '', '']]
 
 
 def do_3Rs(test_dir, conf, modern, single=False):
@@ -34,6 +50,10 @@ def do_3Rs(test_dir, conf, modern, single=False):
     npth_gbr_drl = ctx.get_npth_gbr_drl_filename()
     f1_gbr_drl = ctx.get_f1_gbr_drl_filename()
     i12_gbr_drl = ctx.get_12_gbr_drl_filename()
+    pth_csv_drl = ctx.get_pth_csv_drl_filename()
+    npth_csv_drl = ctx.get_npth_csv_drl_filename()
+    f1_csv_drl = ctx.get_f1_csv_drl_filename()
+    i12_csv_drl = ctx.get_12_csv_drl_filename()
     report = 'report.rpt'
 
     if modern:
@@ -55,11 +75,13 @@ def do_3Rs(test_dir, conf, modern, single=False):
             npth_drl = npth_drl.replace('NPTH_', '')
             pth_pdf_drl = pth_pdf_drl.replace('PTH_', '')
             npth_pdf_drl = npth_pdf_drl.replace('NPTH_', '')
+            npth_csv_drl = npth_csv_drl.replace('_NPTH', '')
     elif single:
         pth_drl = pth_drl.replace('-PTH', '')
         npth_drl = npth_drl.replace('-NPTH', '')
         pth_pdf_drl = pth_pdf_drl.replace('-PTH', '')
         npth_pdf_drl = npth_pdf_drl.replace('-NPTH', '')
+        npth_csv_drl = npth_csv_drl.replace('_NPTH', '')
 
     ctx.expect_out_file(os.path.join(DRILL_DIR, report))
     ctx.expect_out_file(pth_drl)
@@ -74,6 +96,10 @@ def do_3Rs(test_dir, conf, modern, single=False):
     ctx.expect_out_file(npth_pdf_drl)
     ctx.expect_out_file(f1_pdf_drl)
     ctx.expect_out_file(i12_pdf_drl)
+    ctx.expect_out_file(pth_csv_drl)
+    ctx.expect_out_file(npth_csv_drl)
+    ctx.expect_out_file(f1_csv_drl)
+    ctx.expect_out_file(i12_csv_drl)
     # We have R3 at (110, 45) length is 9 mm on X, drill 1 mm
     ctx.search_in_file(pth_drl, ['X110.0Y-45.0', 'X119.0Y-45.0'])
     ctx.expect_gerber_flash_at(pth_gbr_drl, 6, (110, -45))
@@ -82,7 +108,29 @@ def do_3Rs(test_dir, conf, modern, single=False):
     ctx.search_in_file(npth_drl, ['X120.0Y-29.0', 'T.C2.100'])
     ctx.expect_gerber_flash_at(npth_gbr_drl, 6, (120, -29))
     ctx.expect_gerber_has_apertures(npth_gbr_drl, ['C,2.100000'])
+    # Verify the generated drill tables
+    rows_pth, header_pth, _ = ctx.load_csv(pth_csv_drl.replace(DRILL_DIR+'/', ''))
+    logging.debug(f"rows pth {rows_pth}")
+    rows_npth, header_npth, _ = ctx.load_csv(npth_csv_drl.replace(DRILL_DIR+'/', ''))
+    rows_f1, header_f1, _ = ctx.load_csv(f1_csv_drl.replace(DRILL_DIR+'/', ''))
+    rows_12, header_12, _ = ctx.load_csv(i12_csv_drl.replace(DRILL_DIR+'/', ''))
+    if single:
+        table_verif(rows_pth, ROWS_PTH_NPTH, header_pth, context.ki5())
+    else:
+        table_verif(rows_pth, ROWS_PTH, header_pth, context.ki5())
+        table_verif(rows_npth, ROWS_NPTH, header_npth, context.ki5())
+    table_verif(rows_f1, ROWS_F1, header_f1, context.ki5())
+    table_verif(rows_12, ROWS_12, header_12, context.ki5())
     ctx.clean_up()
+
+
+def table_verif(rows, ref_rows, header, ki5):
+    if ki5:
+        assert header == DRILL_TABLE_HEADER[:-1]  # KiCad 5 doesn't have Hole type
+        assert rows == [row[:-1] for row in ref_rows]
+    else:
+        assert header == DRILL_TABLE_HEADER
+        assert rows == ref_rows
 
 
 def test_drill_3Rs(test_dir):

--- a/tests/utils/context.py
+++ b/tests/utils/context.py
@@ -318,8 +318,6 @@ class TestContext(object):
     def get_npth_csv_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-(L1 - L4)_NPTH_drill_table.csv')
 
-
-
     def expect_out_file(self, filename, sub=False):
         if isinstance(filename, str):
             filename = [filename]

--- a/tests/utils/context.py
+++ b/tests/utils/context.py
@@ -279,6 +279,9 @@ class TestContext(object):
     def get_pth_pdf_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-PTH-drl_map.pdf')
 
+    def get_pth_csv_drl_filename(self):
+        return os.path.join(self.sub_dir, self.board_name+'-(L1 - L4)_drill_table.csv')
+
     def get_f1_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-front-in1.drl')
 
@@ -287,6 +290,9 @@ class TestContext(object):
 
     def get_f1_pdf_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-front-in1-drl_map.pdf')
+
+    def get_f1_csv_drl_filename(self):
+        return os.path.join(self.sub_dir, self.board_name+'-(L1 - L2)_drill_table.csv')
 
     def get_12_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-in1-in2.drl')
@@ -297,6 +303,9 @@ class TestContext(object):
     def get_12_pdf_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-in1-in2-drl_map.pdf')
 
+    def get_12_csv_drl_filename(self):
+        return os.path.join(self.sub_dir, self.board_name+'-(L2 - L3)_drill_table.csv')
+
     def get_npth_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-NPTH.drl')
 
@@ -305,6 +314,11 @@ class TestContext(object):
 
     def get_npth_pdf_drl_filename(self):
         return os.path.join(self.sub_dir, self.board_name+'-NPTH-drl_map.pdf')
+
+    def get_npth_csv_drl_filename(self):
+        return os.path.join(self.sub_dir, self.board_name+'-(L1 - L4)_NPTH_drill_table.csv')
+
+
 
     def expect_out_file(self, filename, sub=False):
         if isinstance(filename, str):

--- a/tests/yaml_samples/drill.kibot.yaml
+++ b/tests/yaml_samples/drill.kibot.yaml
@@ -16,13 +16,13 @@ outputs:
       mirror_y_axis: false
       report: '%f-%i.%x'
       map: 'pdf'
-      table:
-        pth_and_npth_single_file: false
 
   - name: gerber_drills
     comment: "Gerber drill files"
     type: gerb_drill
     dir: Drill
     options:
+      table:
+        unify_pth_and_npth: 'auto'
       use_aux_axis_as_origin: false
       map: 'pdf'

--- a/tests/yaml_samples/drill.kibot.yaml
+++ b/tests/yaml_samples/drill.kibot.yaml
@@ -16,6 +16,8 @@ outputs:
       mirror_y_axis: false
       report: '%f-%i.%x'
       map: 'pdf'
+      table:
+        pth_and_npth_single_file: false
 
   - name: gerber_drills
     comment: "Gerber drill files"

--- a/tests/yaml_samples/drill_legacy.kiplot.yaml
+++ b/tests/yaml_samples/drill_legacy.kiplot.yaml
@@ -20,6 +20,8 @@ outputs:
       map:
         output: ''
         type: 'pdf'
+      table:
+        pth_and_npth_single_file: false
 
   - name: gerber_drills
     comment: "Gerber drill files"

--- a/tests/yaml_samples/drill_legacy.kiplot.yaml
+++ b/tests/yaml_samples/drill_legacy.kiplot.yaml
@@ -21,7 +21,7 @@ outputs:
         output: ''
         type: 'pdf'
       table:
-        pth_and_npth_single_file: false
+        unify_pth_and_npth: 'no'
 
   - name: gerber_drills
     comment: "Gerber drill files"

--- a/tests/yaml_samples/drill_legacy_s.kiplot.yaml
+++ b/tests/yaml_samples/drill_legacy_s.kiplot.yaml
@@ -19,14 +19,14 @@ outputs:
       map:
         output: ''
         type: 'pdf'
-      table:
-        pth_and_npth_single_file: true
-
+  
   - name: gerber_drills
     comment: "Gerber drill files"
     type: gerb_drill
     dir: Drill
     options:
+      table:
+        unify_pth_and_npth: 'yes'
       output: ''
       use_aux_axis_as_origin: false
       map:

--- a/tests/yaml_samples/drill_legacy_s.kiplot.yaml
+++ b/tests/yaml_samples/drill_legacy_s.kiplot.yaml
@@ -19,6 +19,8 @@ outputs:
       map:
         output: ''
         type: 'pdf'
+      table:
+        pth_and_npth_single_file: true
 
   - name: gerber_drills
     comment: "Gerber drill files"

--- a/tests/yaml_samples/drill_single.kibot.yaml
+++ b/tests/yaml_samples/drill_single.kibot.yaml
@@ -16,6 +16,8 @@ outputs:
       pth_id: drill
       report: '%f-%i.%x'
       map: 'pdf'
+      table:
+        pth_and_npth_single_file: true
 
   - name: gerber_drills
     comment: "Gerber drill files"

--- a/tests/yaml_samples/drill_single.kibot.yaml
+++ b/tests/yaml_samples/drill_single.kibot.yaml
@@ -17,7 +17,7 @@ outputs:
       report: '%f-%i.%x'
       map: 'pdf'
       table:
-        pth_and_npth_single_file: true
+        unify_pth_and_npth: 'auto'
 
   - name: gerber_drills
     comment: "Gerber drill files"


### PR DESCRIPTION
This PR adds a CSV drill table output to the `excellon` output. I've added a simple test case in `test_drill.py`.
It's basically a reimplementation of
https://gitlab.com/kicad/code/kicad/-/blob/master/pcbnew/exporters/gendrill_file_writer_base.cpp
It should work for KiCad 5+, but for KiCad 5 the generated table is slightly different (because of missing attributes).
The column order/names can be changed similar to how it's done in bom.
Example from `drill.kibot.yaml`
```
# Drills and Gerber drills
kibot:
  version: 1

outputs:

  - name: excellon_drill
    comment: "Excellon drill files"
    type: excellon
    dir: Drill
    options:
      metric_units: true
      pth_and_npth_single_file: false
      use_aux_axis_as_origin: false
      minimal_header: false
      mirror_y_axis: false
      report: '%f-%i.%x'
      map: 'pdf'
      table:
        pth_and_npth_single_file: false

  - name: gerber_drills
    comment: "Gerber drill files"
    type: gerb_drill
    dir: Drill
    options:
      use_aux_axis_as_origin: false
      map: 'pdf'
```

I've also modified the 3Rs_bv.kicad_pcb PCB for KiCad 5, as it was not similar to the other versions (there was a missing through hole via, and the tests I wrote are expecting a similar PCB for all versions)