### PR TITLE
[Report][Added] Expand relative paths to specific outputs

### DIFF
--- a/kibot/out_report.py
+++ b/kibot/out_report.py
@@ -287,8 +287,8 @@ class ReportOptions(VariantOptions):
                 output_name = base_var[:-8]  # Strip `_outpath`
                 try:
                     targets, _, _ = get_output_targets(output_name, self._parent)
+                    target = None
                     if isinstance(targets, list):
-                        target = None
                         if index is not None:
                             if 0 <= index < len(targets):
                                 target = targets[index]
@@ -296,16 +296,11 @@ class ReportOptions(VariantOptions):
                                 logger.warning(f"Index {index + 1} out of range for `{var_ori}`")
                         else:
                             target = targets[0]
-
-                        if target is not None:
-                            target_rel = os.path.relpath(target, os.path.join(GS.out_dir, self._parent.dir))
-                            line = line.replace(f'${{{var_ori}}}', target_rel)
                     else:
                         target = targets
-                        root_folder = defined.get('KIPRJMOD', '')
-                        if target.startswith(root_folder):
-                            target = target[len(root_folder):].lstrip('/')
-                        line = line.replace(f'${{{var_ori}}}', target)
+                    if target is not None:
+                        target_rel = os.path.relpath(target, os.path.join(GS.out_dir, self._parent.dir))
+                        line = line.replace(f'${{{var_ori}}}', target_rel)
                 except Exception as e:
                     logger.warning(f"Error processing _outpath for `{var_ori}`: {str(e)}")
                 continue

--- a/kibot/out_report.py
+++ b/kibot/out_report.py
@@ -26,7 +26,7 @@ from .misc import (UI_SMD, UI_VIRTUAL, MOD_THROUGH_HOLE, MOD_SMD, MOD_EXCLUDE_FR
 from .registrable import RegOutput
 from .out_base import VariantOptions
 from .error import KiPlotConfigurationError
-from .kiplot import config_output, run_command
+from .kiplot import config_output, run_command, get_output_targets
 from .dep_downloader import get_dep_data
 from .macros import macros, document, output_class  # noqa: F401
 from . import log
@@ -275,6 +275,40 @@ class ReportOptions(VariantOptions):
             if m:
                 pattern = m.group(1)
                 var = m.group(2)
+            # Handle `_outpath` with optional indexing
+            if var.endswith('_outpath') or '_outpath_' in var:
+                base_var = var
+                index = None
+                idx_match = re.match(r'^(.*)_outpath_(\d+)$', var)
+                if idx_match:
+                    base_var = idx_match.group(1) + '_outpath'
+                    index = int(idx_match.group(2)) - 1  # Convert 1-based to 0-based index
+
+                output_name = base_var[:-8]  # Strip `_outpath`
+                try:
+                    targets, _, _ = get_output_targets(output_name, self._parent)
+                    if isinstance(targets, list):
+                        target = None
+                        if index is not None:
+                            if 0 <= index < len(targets):
+                                target = targets[index]
+                            else:
+                                logger.warning(f"Index {index + 1} out of range for `{var_ori}`")
+                        else:
+                            target = targets[0]
+
+                        if target is not None:
+                            target_rel = os.path.relpath(target, os.path.join(GS.out_dir, self._parent.dir))
+                            line = line.replace(f'${{{var_ori}}}', target_rel)
+                    else:
+                        target = targets
+                        root_folder = defined.get('KIPRJMOD', '')
+                        if target.startswith(root_folder):
+                            target = target[len(root_folder):].lstrip('/')
+                        line = line.replace(f'${{{var_ori}}}', target)
+                except Exception as e:
+                    logger.warning(f"Error processing _outpath for `{var_ori}`: {str(e)}")
+                continue
             if var.endswith('_mm'):
                 units = to_mm
                 digits = self.mm_digits

--- a/tests/data/report_output_path.txt
+++ b/tests/data/report_output_path.txt
@@ -1,0 +1,6 @@
+${pcb_print_png_outpath}
+${pcb_print_png_outpath_1}
+${pcb_print_png_outpath_2}
+${pcb_print_png_outpath_3}
+${pcb_print_png_outpath_4}
+${pcb_print_png_outpath_5}

--- a/tests/reference/5_1_7/light_control-report_output_path_1.txt
+++ b/tests/reference/5_1_7/light_control-report_output_path_1.txt
@@ -1,0 +1,7 @@
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_02.png
+../png/light_control-assembly_page_03.png
+../png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/5_1_7/light_control-report_output_path_2.txt
+++ b/tests/reference/5_1_7/light_control-report_output_path_2.txt
@@ -1,0 +1,7 @@
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_02.png
+png/light_control-assembly_page_03.png
+png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/6_0_8/light_control-report_output_path_1.txt
+++ b/tests/reference/6_0_8/light_control-report_output_path_1.txt
@@ -1,7 +1,1 @@
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_02.png
-../png/light_control-assembly_page_03.png
-../png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_1.txt

--- a/tests/reference/6_0_8/light_control-report_output_path_1.txt
+++ b/tests/reference/6_0_8/light_control-report_output_path_1.txt
@@ -1,0 +1,7 @@
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_02.png
+../png/light_control-assembly_page_03.png
+../png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/6_0_8/light_control-report_output_path_2.txt
+++ b/tests/reference/6_0_8/light_control-report_output_path_2.txt
@@ -1,0 +1,7 @@
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_02.png
+png/light_control-assembly_page_03.png
+png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/6_0_8/light_control-report_output_path_2.txt
+++ b/tests/reference/6_0_8/light_control-report_output_path_2.txt
@@ -1,7 +1,1 @@
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_02.png
-png/light_control-assembly_page_03.png
-png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_2.txt

--- a/tests/reference/7_0_0/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_0/light_control-report_output_path_1.txt
@@ -1,7 +1,1 @@
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_02.png
-../png/light_control-assembly_page_03.png
-../png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_1.txt

--- a/tests/reference/7_0_0/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_0/light_control-report_output_path_1.txt
@@ -1,0 +1,7 @@
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_02.png
+../png/light_control-assembly_page_03.png
+../png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_0/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_0/light_control-report_output_path_2.txt
@@ -1,0 +1,7 @@
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_02.png
+png/light_control-assembly_page_03.png
+png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_0/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_0/light_control-report_output_path_2.txt
@@ -1,7 +1,1 @@
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_02.png
-png/light_control-assembly_page_03.png
-png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_2.txt

--- a/tests/reference/7_0_10/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_10/light_control-report_output_path_1.txt
@@ -1,7 +1,1 @@
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_02.png
-../png/light_control-assembly_page_03.png
-../png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_1.txt

--- a/tests/reference/7_0_10/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_10/light_control-report_output_path_1.txt
@@ -1,0 +1,7 @@
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_02.png
+../png/light_control-assembly_page_03.png
+../png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_10/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_10/light_control-report_output_path_2.txt
@@ -1,0 +1,7 @@
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_02.png
+png/light_control-assembly_page_03.png
+png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_10/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_10/light_control-report_output_path_2.txt
@@ -1,7 +1,1 @@
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_02.png
-png/light_control-assembly_page_03.png
-png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_2.txt

--- a/tests/reference/7_0_3/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_3/light_control-report_output_path_1.txt
@@ -1,7 +1,1 @@
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_02.png
-../png/light_control-assembly_page_03.png
-../png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_1.txt

--- a/tests/reference/7_0_3/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_3/light_control-report_output_path_1.txt
@@ -1,0 +1,7 @@
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_02.png
+../png/light_control-assembly_page_03.png
+../png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_3/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_3/light_control-report_output_path_2.txt
@@ -1,0 +1,7 @@
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_02.png
+png/light_control-assembly_page_03.png
+png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_3/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_3/light_control-report_output_path_2.txt
@@ -1,7 +1,1 @@
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_02.png
-png/light_control-assembly_page_03.png
-png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_2.txt

--- a/tests/reference/7_0_6/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_6/light_control-report_output_path_1.txt
@@ -1,7 +1,1 @@
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_02.png
-../png/light_control-assembly_page_03.png
-../png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_1.txt

--- a/tests/reference/7_0_6/light_control-report_output_path_1.txt
+++ b/tests/reference/7_0_6/light_control-report_output_path_1.txt
@@ -1,0 +1,7 @@
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_02.png
+../png/light_control-assembly_page_03.png
+../png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_6/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_6/light_control-report_output_path_2.txt
@@ -1,0 +1,7 @@
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_02.png
+png/light_control-assembly_page_03.png
+png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/7_0_6/light_control-report_output_path_2.txt
+++ b/tests/reference/7_0_6/light_control-report_output_path_2.txt
@@ -1,7 +1,1 @@
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_02.png
-png/light_control-assembly_page_03.png
-png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_2.txt

--- a/tests/reference/8_0_0/light_control-report_output_path_1.txt
+++ b/tests/reference/8_0_0/light_control-report_output_path_1.txt
@@ -1,7 +1,1 @@
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_01.png
-../png/light_control-assembly_page_02.png
-../png/light_control-assembly_page_03.png
-../png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_1.txt

--- a/tests/reference/8_0_0/light_control-report_output_path_1.txt
+++ b/tests/reference/8_0_0/light_control-report_output_path_1.txt
@@ -1,0 +1,7 @@
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_01.png
+../png/light_control-assembly_page_02.png
+../png/light_control-assembly_page_03.png
+../png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/8_0_0/light_control-report_output_path_2.txt
+++ b/tests/reference/8_0_0/light_control-report_output_path_2.txt
@@ -1,0 +1,7 @@
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_01.png
+png/light_control-assembly_page_02.png
+png/light_control-assembly_page_03.png
+png/light_control-assembly_page_04.png
+${pcb_print_png_outpath_5}
+

--- a/tests/reference/8_0_0/light_control-report_output_path_2.txt
+++ b/tests/reference/8_0_0/light_control-report_output_path_2.txt
@@ -1,7 +1,1 @@
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_01.png
-png/light_control-assembly_page_02.png
-png/light_control-assembly_page_03.png
-png/light_control-assembly_page_04.png
-${pcb_print_png_outpath_5}
-
+../5_1_7/light_control-report_output_path_2.txt

--- a/tests/test_plot/test_misc.py
+++ b/tests/test_plot/test_misc.py
@@ -1203,6 +1203,17 @@ def test_report_edge_2(test_dir):
     ctx.clean_up()
 
 
+def test_report_output_path(test_dir):
+    prj = 'light_control'
+    ctx = context.TestContext(test_dir, prj, 'report_output_path', POS_DIR)
+    ctx.run(extra=['pcb_print_png', 'report_output_path_1', 'report_output_path_2'])
+    ctx.expect_out_file('report/'+prj+'-report_output_path_1.txt')
+    ctx.expect_out_file(prj+'-report_output_path_2.txt')
+    ctx.compare_txt('report/'+prj+'-report_output_path_1.txt', reference=prj+'-report_output_path_1.txt')
+    ctx.compare_txt(prj+'-report_output_path_2.txt')
+    ctx.clean_up(keep_project=True)
+
+
 def test_board_view_1(test_dir):
     prj = 'glasgow'
     ctx = context.TestContext(test_dir, prj, 'boardview', POS_DIR)

--- a/tests/yaml_samples/report_output_path.kibot.yaml
+++ b/tests/yaml_samples/report_output_path.kibot.yaml
@@ -1,0 +1,32 @@
+# Example KiBot config file
+kibot:
+  version: 1
+
+outputs:
+  - name: 'report_output_path_1'
+    comment: "Design report with output paths expansions"
+    type: report
+    output_id: _output_path_1
+    dir: report
+    options:
+      template: tests/data/report_output_path.txt
+
+  - name: 'report_output_path_2'
+    comment: "Design report with output paths expansions"
+    type: report
+    output_id: _output_path_2
+    dir: .
+    options:
+      template: tests/data/report_output_path.txt
+
+  - name: 'pcb_print_png'
+    comment: "Top & Bottom in PNG"
+    type: pcb_print
+    dir: png
+    options:
+      format: 'PNG'
+      pages:
+        - repeat_layers: 'copper'
+          repeat_for_layer: F.Cu
+          layers:
+            - layer: F.Cu


### PR DESCRIPTION
This PR adds to the `report` output a new expansion pattern `${<output_name>_outpath_<index>}` (index optional, starts at 1), which returns the relative path between the generated report file and the output. This is useful for creating README files or other files that need a relative path to a specific file.

Example configuration:
https://github.com/nguyen-v/KiBot/blob/report_out_path/tests/yaml_samples/report_output_path.kibot.yaml

With this template:
https://github.com/nguyen-v/KiBot/blob/report_out_path/tests/data/report_output_path.txt

Generates:
https://github.com/nguyen-v/KiBot/blob/report_out_path/tests/reference/8_0_0/light_control-report_output_path_1.txt
https://github.com/nguyen-v/KiBot/blob/report_out_path/tests/reference/8_0_0/light_control-report_output_path_2.txt