### PR TITLE
fix missing kicost config file parameter and expand env variables

### DIFF
--- a/kibot/out_kicost.py
+++ b/kibot/out_kicost.py
@@ -215,10 +215,10 @@ class KiCostOptions(VariantOptions):
             cmd.extend(self.translate_fields)
         # Config specified by the user
         if self.kicost_config:
-            cfg_name = os.path.expanduser(self.kicost_config)
+            cfg_name = os.path.abspath(os.path.expandvars(os.path.expanduser(self.kicost_config)))
             if not os.path.isfile(cfg_name):
                 raise KiPlotConfigurationError(f"Missing config file: `{cfg_name}`")
-            cmd.extend(['--config', ])
+            cmd.extend(['--config', cfg_name])
         # Run the command
         try:
             run_command(cmd, err_msg='Failed to create costs spreadsheet, error {ret}', err_lvl=BOM_ERROR)


### PR DESCRIPTION
The 'kicost_config' parameter from the KiCost output job configuration was not added when constructing the KiCost command line.  Also expand environment variables in 'kicost_config' parameter.