### PR TITLE
[Bug] fix division by zero when parsing component values

### DIFF
--- a/kibot/bom/units.py
+++ b/kibot/bom/units.py
@@ -219,12 +219,17 @@ def comp_match(component, ref_prefix, ref=None, relax_severity=False, stronger=F
         # This is used to parse things like "1/8 W", but we get "1/8" here
         result = re.match(r'(\d+)\/(\d+)', component)
         if result:
-            val = int(result.group(1))/int(result.group(2))
-            val, pow = get_prefix(val, '')
-            parsed = ParsedValue(val, pow, get_unit('', ref_prefix))
-            # Cache the result
-            parser_cache[original+ref_prefix] = parsed
-            return parsed
+            # Avoid division by zero
+            if int(result.group(2)) != 0:
+                val = int(result.group(1))/int(result.group(2))
+                val, pow = get_prefix(val, '')
+                parsed = ParsedValue(val, pow, get_unit('', ref_prefix))
+                # Cache the result
+                parser_cache[original+ref_prefix] = parsed
+                return parsed
+            else
+                result = None
+                
     if not result:
         # Failed with the regex, try with the parser
         result = parse(ref_prefix[0]+' '+with_commas, with_extra=True, stronger=stronger)


### PR DESCRIPTION
We are using some values like "22/0.1%" and it pass into this regex and return an error with divison by zero : 

  File "/usr/lib/python3/dist-packages/kibot/bom/units.py", line 222, in comp_match
    val = int(result.group(1))/int(result.group(2))
          ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
ZeroDivisionError: division by zero

After some test we found that there are no issue if the first part "22" is "22R" or "22k" and no errors if the second part is "1%", "5%" or if the value contains a space after the "/".