### PR TITLE
Support updating text variables in .kicad_pcb file explicitly

### DIFF
--- a/kibot/globals.py
+++ b/kibot/globals.py
@@ -392,11 +392,20 @@ class Globals(FiltersOptions):
             """ [string|list(string)] Name/s of the field/s used for the current raiting.
                 You can use `_field_current` as field name to use it in most places """
             self.invalidate_pcb_text_cache = 'auto'
-            """ [auto,yes,no] Remove any cached text variable in the PCB. This is needed in order to force a text
-                variables update when using `set_text_variables`. You might want to disable it when applying some
-                changes to the PCB and create a new copy to send to somebody without changing the cached values.
-                Note that it will save the PCB with the cache erased.
-                The `auto` value will remove the cached values only when using `set_text_variables` """
+            """ [auto,yes,no] Clear the text variables cache in the PCB file. This is needed in order to force KiCad to read
+                updated text variables from the project file when they are changed with `set_text_variables`. You might want to
+                disable it when applying some changes to the PCB and create a new copy to send to somebody without changing the
+                cached values.
+                The `auto` value will remove the cached values only when using `set_text_variables`.
+                Note that at least one of the `invalidate_pcb_text_cache` and `update_pcb_text_cache` config values must be set
+                to 'no', otherwise an error is produced."""
+            self.update_pcb_text_cache = 'no'
+            """ [auto,yes,no] Update the text variables cache in the PCB file. This makes the PCB file self-contained (usable
+                without the project file next to it) by copying all text variables from the project file (possibly modified by
+                the `set_text_variables` preflight) into the PCB file (the cache is completely replaced).
+                The `auto` value will update the cache only when using `set_text_variables`.
+                Note that at least one of the `invalidate_pcb_text_cache` and `update_pcb_text_cache` config values must be set
+                to 'no', otherwise an error is produced."""
             self.git_diff_strategy = 'worktree'
             """ [worktree,stash] When computing a PCB/SCH diff it configures how do we preserve the current
                 working state. The *worktree* mechanism creates a separated worktree, that then is just removed.
@@ -581,6 +590,9 @@ class Globals(FiltersOptions):
                 KiConf.aliases_3D[alias.name] = alias.value
                 logger.debugl(1, '- {}={}'.format(alias.name, alias.value))
             logger.debugl(1, 'Finished adding aliases')
+        if GS.global_invalidate_pcb_text_cache != 'no' and GS.global_update_pcb_text_cache != 'no':
+            raise KiPlotConfigurationError("At least one of `invalidate_pcb_text_cache` and `update_pcb_text_cache`"
+                                           " option must be `no`")
 
 
 logger = get_logger(__name__)

--- a/kibot/gs.py
+++ b/kibot/gs.py
@@ -185,6 +185,7 @@ class GS(object):
     global_git_diff_strategy = None
     global_impedance_controlled = None
     global_invalidate_pcb_text_cache = None
+    global_update_pcb_text_cache = None
     global_kiauto_time_out_scale = None
     global_kiauto_wait_start = None
     global_layer_defaults = None

--- a/kibot/pre_set_text_variables.py
+++ b/kibot/pre_set_text_variables.py
@@ -163,7 +163,10 @@ class Set_Text_Variables(BasePreFlight):  # noqa: F821
         if GS.board:
             # Force a project and PCB reload
             GS.reload_project(pro_name)
-        # Check if we need to force a PCB text variables reset
+        # Check if we need to force a PCB text variables reset or update
         if GS.global_invalidate_pcb_text_cache == 'auto':
             logger.debug('Forcing PCB text variables reset')
             GS.global_invalidate_pcb_text_cache = 'yes'
+        if GS.global_update_pcb_text_cache == 'auto':
+            logger.debug('Forcing PCB text variables update')
+            GS.global_update_pcb_text_cache = 'yes'


### PR DESCRIPTION
Normally, the text variables in the .kicad_pcb file are cleared when requested, or when changing them with the set_text_variables preflight. This causes KiCad to load the variables from the project file when opening the PCB, but this does not work when the .kicad_pcb file is used in isolation (e.g. when submitting to a PCB manufacturer).

This commit adds support for invalidate_pcb_text_cache=update, which causes kibot to explicitly write the (updated / current) variables to the .kicad_pcb file, making it self-contained.

This fixes #860