### PR TITLE
fix: make --fail-on-warnings respect filters by default

### DIFF
--- a/kibot/__main__.py
+++ b/kibot/__main__.py
@@ -669,7 +669,7 @@ def main():
     if args.fail_on_ignored and (GS.errors_ignored or log.errors_ignored):
         exit(IGNORED_ERRORS)
 
-    if args.fail_on_warnings and logger.got_warnings():
+    if args.fail_on_warnings and logger.got_warnings(args.fail_on_ignored):
         exit(GOT_WARNINGS)
 
 

--- a/kibot/log.py
+++ b/kibot/log.py
@@ -203,8 +203,11 @@ class MyLogger(logging.Logger):
                 filt_msg = ', {} filtered'.format(MyLogger.n_filtered)
             self.info('Found {} unique warning/s ({} total{})'.format(MyLogger.warn_cnt, MyLogger.warn_tcnt, filt_msg))
 
-    def got_warnings(self):
-        return MyLogger.warn_cnt or MyLogger.warn_tcnt
+    def got_warnings(self, fail_on_ignored=False):
+        if fail_on_ignored:
+            return MyLogger.warn_tcnt
+        else:
+            return MyLogger.warn_cnt
 
     def non_critical_error(self, msg, *args, **kwargs):
         buf = str(msg)


### PR DESCRIPTION
The current implementation of `--fail-on-warnings` triggers a failure (39)
on any warning, ignoring the filtering system.
    
This change aligns `--fail-on-warnings` with the logic of `--fail-on-ignored` (-F).
* By default, only unfiltered (unique) warnings trigger a failure.
* If `--fail-on-ignored` is active, any warning (including filtered
   ones) will trigger the failure.
    
See #828
