### PR TITLE
Set inject/redo pcb text vars in k10 for QR Codes and Barcodes

### DIFF
--- a/kibot/globals.py
+++ b/kibot/globals.py
@@ -424,7 +424,7 @@ class Globals(FiltersOptions):
                 The `auto` value will remove the cached values only when using `set_text_variables`.
                 Note that at least one of the `invalidate_pcb_text_cache` and `update_pcb_text_cache` config values must be set
                 to 'no', otherwise an error is produced."""
-            self.update_pcb_text_cache = 'no'
+            self.update_pcb_text_cache = 'auto'
             """ [auto,yes,no] Update the text variables cache in the PCB file. This makes the PCB file self-contained (usable
                 without the project file next to it) by copying all text variables from the project file (possibly modified by
                 the `set_text_variables` preflight) into the PCB file (the cache is completely replaced).
@@ -618,7 +618,7 @@ class Globals(FiltersOptions):
                 KiConf.aliases_3D[alias.name] = alias.value
                 logger.debugl(1, '- {}={}'.format(alias.name, alias.value))
             logger.debugl(1, 'Finished adding aliases')
-        if GS.global_invalidate_pcb_text_cache != 'no' and GS.global_update_pcb_text_cache != 'no':
+        if GS.global_invalidate_pcb_text_cache == 'yes' and GS.global_update_pcb_text_cache == 'yes':
             raise KiPlotConfigurationError("At least one of `invalidate_pcb_text_cache` and `update_pcb_text_cache`"
                                            " option must be `no`")
 

--- a/kibot/pre_set_text_variables.py
+++ b/kibot/pre_set_text_variables.py
@@ -186,10 +186,10 @@ class Set_Text_Variables(BasePreFlight):  # noqa: F821
         if GS.board:
             # Force a project and PCB reload
             GS.reload_project(pro_name)
-        # Check if we need to force a PCB text variables reset or update
-        if GS.global_invalidate_pcb_text_cache == 'auto':
-            logger.debug('Forcing PCB text variables reset')
-            GS.global_invalidate_pcb_text_cache = 'yes'
+        # Force PCB Cache update for native QR/barcodes in auto
         if GS.global_update_pcb_text_cache == 'auto':
             logger.debug('Forcing PCB text variables update')
             GS.global_update_pcb_text_cache = 'yes'
+        if GS.global_invalidate_pcb_text_cache == 'auto':
+            logger.debug('Skipping PCB text variables reset')
+            GS.global_invalidate_pcb_text_cache = 'no'


### PR DESCRIPTION
Enforce 'auto' for setting pcb text vars, text vars set on project file only dont force native chunks in k10 to re-render (mostly qr codes)