### PR TITLE
[Render 3D][Fixed] Avoid --use-board-stackup-colors consuming INPUT_FILE

### DIFF
--- a/kibot/out_render_3d.py
+++ b/kibot/out_render_3d.py
@@ -452,9 +452,7 @@ class Render3DOptions(Base3DOptionsWithHL):
                # '--floor' enables options that are already enabled in "high" (ray trace)
                # '--perspective' conditionally added
                # '--zoom' added as Z in --pan
-               '--pan', f"{self.move_x},{self.move_y},{self.zoom}",
-               '--pivot', f"{self.pivot_x},{self.pivot_y},{self.pivot_z}",
-               '--rotate', f"{rx},{ry},{rz}",
+               # '--pan'/'--pivot'/'--rotate' added after the --use-board-stackup-colors flag
                # TODO: --light*
                ]
         if self.force_stackup_colors:
@@ -463,6 +461,10 @@ class Render3DOptions(Base3DOptionsWithHL):
             cmd.append('--perspective')
         if GS.kicad_version_n >= KICAD_VERSION_10_0_3:
             self.add_kicad_cli_variant(cmd)
+
+        cmd += ['--pan', f"{self.move_x},{self.move_y},{self.zoom}",
+                '--pivot', f"{self.pivot_x},{self.pivot_y},{self.pivot_z}",
+                '--rotate', f"{rx},{ry},{rz}"]
 
         # All the rest of the options are controlled by the preset
         cfg = os.path.join(GS.kicad_conf_path, '3d_viewer.json')


### PR DESCRIPTION
With kicad-cli 10.0.4, --use-board-stackup-colors tries to greedily accept an argument after it, so if it's the last argument in your kicad-cli call, then it greedily consumes `INPUT_FILE` and kicad-cli errors out saying you've not passed a filename.

This change forces --pan / --pivot / --rotate to be the last in the chain, as we know those always have a parameter value after it.

The error was showing:

```
ERROR:Running ['kicad-cli', 'pcb', 'render', '--output', '/builds/render.png', '--width', '3856', '--height', '2176', '--side', 'bottom', '--background', 'transparent', '--quality', 'basic', '--preset', '_kibot_preset', '--pan', '0,0,0', '--pivot', '0,0,0', '--rotate', '0,0,0', '--use-board-stackup-colors', '/builds/board.kicad_pcb'] returned 1 (kibot.gs - gs.py:937)
```

But, from the kicad-cli help:

`--use-board-stackup-colors  Colors defined in board stackup override those in preset [nargs=0..1] [default: false]`

the "nargs 0..1" tries to capture the final `INPUT_FILE` 