### PR TITLE
Feature/kiri explicit commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [1.9.1] - UNRELEASED
 ### Added
 - Support for Python 3.14 (#930)
@@ -55,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *SCH Print
   - `title_propagate`: The title is not only set for page 1 but also for
     all pages.
+- KiRi: `commits` and `labels` options to include an explicit list of git
+  revisions (hashes, tags, branches, etc.) instead of using `max_commits` and
+  `revision`. The order in `commits` is preserved in the KiRI interface and
+  optional `labels` replace the commit subject (useful for release names).
 
 ## Fixed
 - Warnings:

--- a/kibot/out_kiri.py
+++ b/kibot/out_kiri.py
@@ -87,6 +87,8 @@ class KiRiOptions(AnyDiffOptions):
                 Useful to show release names instead of commit messages """
             self.keep_generated = False
             """ *Avoid PCB and SCH images regeneration. Useful for incremental usage """
+            self.include_dirty = True
+            """ When false, do not add uncommitted local changes (_local_) to the commit list """
         super().__init__()
         self.add_to_doc("zones", "Be careful with the *keep_generated* option when changing this setting")
         self._kiri_mode = True
@@ -103,6 +105,9 @@ class KiRiOptions(AnyDiffOptions):
         if self.labels and len(self.labels) != len(self.commits):
             raise KiPlotConfigurationError('`labels` must have the same length as `commits` '
                                            f'({len(self.labels)} != {len(self.commits)})')
+
+    def _add_dirty_local(self, sch_dirty, pcb_dirty):
+        return self.include_dirty and (sch_dirty or pcb_dirty)
 
     def _log_format(self):
         return ['log', '-1', "--date=format:%Y-%m-%d %H:%M:%S", '--pretty=format:%H | %ad | %an | %s']
@@ -135,14 +140,14 @@ class KiRiOptions(AnyDiffOptions):
     def _get_targets(self, out_dir, only_index=False):
         self.init_tools(out_dir)
         hashes, sch_dirty, pcb_dirty, sch_files = self.collect_hashes()
-        if len(hashes) + (1 if sch_dirty or pcb_dirty else 0) < 2:
+        if len(hashes) + (1 if self._add_dirty_local(sch_dirty, pcb_dirty) else 0) < 2:
             return []
         if only_index:
             return [os.path.join(self.cache_dir, 'index.html')]
         files = [os.path.join(self.cache_dir, f) for f in ['index.html', 'blank.svg', 'commits', 'kiri-server', 'project']]
         for h in hashes:
             files.append(os.path.join(self.cache_dir, h[0][:7]))
-        if sch_dirty or pcb_dirty:
+        if self._add_dirty_local(sch_dirty, pcb_dirty):
             files.append(os.path.join(self.cache_dir, HASH_LOCAL))
         return files
 
@@ -341,7 +346,7 @@ class KiRiOptions(AnyDiffOptions):
         self.init_tools(self._parent.output_dir)
         hashes, sch_dirty, pcb_dirty, sch_files = self.collect_hashes()
         # Ensure we have at least 2
-        if len(hashes) + (1 if sch_dirty or pcb_dirty else 0) < 2:
+        if len(hashes) + (1 if self._add_dirty_local(sch_dirty, pcb_dirty) else 0) < 2:
             logger.warning(W_NOTHCMP+'Nothing to compare')
             return
         # Get more information about what is changed
@@ -387,7 +392,7 @@ class KiRiOptions(AnyDiffOptions):
                 if git_tmp_wd:
                     self.remove_git_worktree(git_tmp_wd)
             # Do we have modifications?
-            if sch_dirty or pcb_dirty:
+            if self._add_dirty_local(sch_dirty, pcb_dirty):
                 # Include the current files
                 dst_dir = os.path.join(self.cache_dir, HASH_LOCAL)
                 already_generated = os.path.isdir(dst_dir)
@@ -454,7 +459,7 @@ class KiRi(BaseOutput):  # noqa: F821
             ops = KiRiOptions()
             ops.git_command = git_command
             hashes, sch_dirty, pcb_dirty, _ = ops.collect_hashes()
-            if sch_dirty or pcb_dirty:
+            if ops._add_dirty_local(sch_dirty, pcb_dirty):
                 hashes.append(HASH_LOCAL)
             if len(hashes) < 2:
                 return None

--- a/kibot/out_kiri.py
+++ b/kibot/out_kiri.py
@@ -71,10 +71,20 @@ class KiRiOptions(AnyDiffOptions):
             self.background_color = "#FFFFFF"
             """ Color used for the background of the diff canvas """
             self.max_commits = 0
-            """ Maximum number of commits to include. Use 0 for all available commits """
+            """ Maximum number of commits to include. Use 0 for all available commits.
+                Ignored when *commits* is not empty """
             self.revision = 'HEAD'
             """ Starting point for the commits, can be a branch, a hash, etc.
-                Note that this can be a revision-range, consult the gitrevisions manual for more information """
+                Note that this can be a revision-range, consult the gitrevisions manual for more information.
+                Ignored when *commits* is not empty """
+            self.commits = []
+            """ [string|list(string)] Explicit list of git revisions (commit hashes, tags, branches, etc.).
+                When not empty this list is used as-is and *max_commits* and *revision* are ignored.
+                The order in the list is preserved in the KiRI user interface """
+            self.labels = []
+            """ [string|list(string)] Optional labels for the *commits* list. Must have the same length.
+                When provided they replace the commit subject in the KiRI interface.
+                Useful to show release names instead of commit messages """
             self.keep_generated = False
             """ *Avoid PCB and SCH images regeneration. Useful for incremental usage """
         super().__init__()
@@ -86,6 +96,41 @@ class KiRiOptions(AnyDiffOptions):
         self.validate_colors(['background_color'])
         if self.max_commits < 0:
             raise KiPlotConfigurationError(f"Wrong number of commits ({self.max_commits}) must be positive")
+        if isinstance(self.commits, str):
+            self.commits = [self.commits] if self.commits else []
+        if isinstance(self.labels, str):
+            self.labels = [self.labels] if self.labels else []
+        if self.labels and len(self.labels) != len(self.commits):
+            raise KiPlotConfigurationError('`labels` must have the same length as `commits` '
+                                           f'({len(self.labels)} != {len(self.commits)})')
+
+    def _log_format(self):
+        return ['log', '-1', "--date=format:%Y-%m-%d %H:%M:%S", '--pretty=format:%H | %ad | %an | %s']
+
+    def _parse_log_entry(self, res, label=None):
+        if not res:
+            return None
+        entry = res.split(' | ')
+        if label:
+            entry[3] = label
+        return entry
+
+    def _collect_hashes_explicit(self):
+        hashes = []
+        self._resolved_commits = []
+        for i, rev in enumerate(self.commits):
+            try:
+                full_hash = self.run_git(['rev-parse', '--verify', rev], just_raise=True)
+            except CalledProcessError:
+                raise KiPlotConfigurationError(f"Unknown git revision in `commits`: `{rev}`") from None
+            label = self.labels[i] if i < len(self.labels) else None
+            res = self.run_git(self._log_format() + [full_hash])
+            entry = self._parse_log_entry(res, label)
+            if entry is None:
+                raise KiPlotConfigurationError(f"Unable to get git log for revision `{rev}`")
+            hashes.append(entry)
+            self._resolved_commits.append(full_hash)
+        return hashes
 
     def _get_targets(self, out_dir, only_index=False):
         self.init_tools(out_dir)
@@ -189,10 +234,21 @@ class KiRiOptions(AnyDiffOptions):
             f.write((GS.pcb_title or 'No title')+'|'+(GS.pcb_rev or '')+'|'+(GS.pcb_date or today)+'\n')
 
     def get_modified_status(self, pcb_file, sch_files):
-        res = self.run_git(['log', '--pretty=format:%H', self.revision] + self._max_commits + ['--', pcb_file])
-        self.commits_with_changed_pcb = set(res.split())
-        res = self.run_git(['log', '--pretty=format:%H', self.revision] + self._max_commits + ['--'] + sch_files)
-        self.commits_with_changed_sch = set(res.split())
+        if self.commits:
+            self.commits_with_changed_pcb = set()
+            self.commits_with_changed_sch = set()
+            for full_hash in self._resolved_commits:
+                res = self.run_git(['log', '--pretty=format:%H', '-n', '1', full_hash, '--', pcb_file])
+                if res:
+                    self.commits_with_changed_pcb.add(res)
+                res = self.run_git(['log', '--pretty=format:%H', '-n', '1', full_hash, '--'] + sch_files)
+                if res:
+                    self.commits_with_changed_sch.add(res)
+        else:
+            res = self.run_git(['log', '--pretty=format:%H', self.revision] + self._max_commits + ['--', pcb_file])
+            self.commits_with_changed_pcb = set(res.split())
+            res = self.run_git(['log', '--pretty=format:%H', self.revision] + self._max_commits + ['--'] + sch_files)
+            self.commits_with_changed_sch = set(res.split())
         if GS.debug_level > 1:
             logger.debug(f'Commits with changes in the PCB: {self.commits_with_changed_pcb}')
             logger.debug(f'Commits with changes in the Schematics: {self.commits_with_changed_sch}')
@@ -268,11 +324,15 @@ class KiRiOptions(AnyDiffOptions):
         self.pcb_rel_name = self.run_git(['ls-files', '--full-name', GS.pcb_file])
         if not self.pcb_rel_name:
             raise KiPlotConfigurationError("The PCB must be committed")
-        # Get a list of hashes where we have changes
-        self._max_commits = ['-n', str(self.max_commits)] if self.max_commits else []
-        cmd = ['log', "--date=format:%Y-%m-%d %H:%M:%S", '--pretty=format:%H | %ad | %an | %s']
-        res = self.run_git(cmd + self._max_commits + [self.revision, '--', GS.pcb_file] + sch_files)
-        hashes = [r.split(' | ') for r in res.split('\n')]
+        if self.commits:
+            hashes = self._collect_hashes_explicit()
+        else:
+            # Get a list of hashes where we have changes
+            self._resolved_commits = []
+            self._max_commits = ['-n', str(self.max_commits)] if self.max_commits else []
+            cmd = ['log', "--date=format:%Y-%m-%d %H:%M:%S", '--pretty=format:%H | %ad | %an | %s']
+            res = self.run_git(cmd + self._max_commits + [self.revision, '--', GS.pcb_file] + sch_files)
+            hashes = [r.split(' | ') for r in res.split('\n') if r]
         sch_dirty = self.git_dirty(GS.sch_file)
         pcb_dirty = self.git_dirty(GS.pcb_file)
         return hashes, sch_dirty, pcb_dirty, sch_files

--- a/tests/test_plot/test_misc.py
+++ b/tests/test_plot/test_misc.py
@@ -1619,6 +1619,42 @@ def test_diff_kiri_1(test_dir):
     ctx.clean_up(keep_project=True)
 
 
+@pytest.mark.slow
+@pytest.mark.eeschema
+def test_diff_kiri_commits(test_dir):
+    """ KiRi with an explicit list of git revisions """
+    prj = 'light_control'
+    yaml = 'kiri_commits'
+    ctx = context.TestContext(test_dir, prj, yaml)
+    git_init(ctx)
+    pcb = prj+'.kicad_pcb'
+    sch = prj+context.KICAD_SCH_EXT
+    file = ctx.get_out_path(pcb)
+    shutil.copy2(ctx.board_file, file)
+    shutil.copy2(ctx.board_file.replace('.kicad_pcb', context.KICAD_SCH_EXT),
+                 file.replace('.kicad_pcb', context.KICAD_SCH_EXT))
+    ctx.run_command(['git', 'add', pcb, sch], chdir_out=True)
+    ctx.run_command(['git', 'commit', '-m', 'Reference'], chdir_out=True)
+    ctx.run_command(['git', 'tag', '-a', 'v1', '-m', 'Tag description'], chdir_out=True)
+    hash1 = ctx.run_command(['git', 'log', '--pretty=format:%h', '-n', '1'], chdir_out=True)
+    shutil.copy2(ctx.board_file.replace(prj, prj+'_diff'), file)
+    shutil.copy2(ctx.board_file.replace(prj, prj+'_diff').replace('.kicad_pcb', context.KICAD_SCH_EXT),
+                 file.replace('.kicad_pcb', context.KICAD_SCH_EXT))
+    ctx.run_command(['git', 'add', pcb, sch], chdir_out=True)
+    ctx.run_command(['git', 'commit', '-m', 'New version'], chdir_out=True)
+    hash2 = ctx.run_command(['git', 'log', '--pretty=format:%h', '-n', '1'], chdir_out=True)
+    ctx.run(extra=['-b', file], no_board_file=True, extra_debug=True)
+    ctx.expect_out_file([hash1+'/_KIRI_/pcb_layers', hash2+'/_KIRI_/pcb_layers',
+                         hash1+'/_KIRI_/sch_sheets', hash2+'/_KIRI_/sch_sheets',
+                         'index.html', 'commits', 'project'])
+    commits_txt = ctx.get_out_path('commits')
+    with open(commits_txt, 'rt') as f:
+        commits = f.read()
+    assert 'Release v1' in commits
+    assert 'Release v2' in commits
+    ctx.clean_up(keep_project=True)
+
+
 def test_diff_git_2(test_dir):
     """ Difference between the two repo points, wipe the current file """
     prj = 'light_control'

--- a/tests/yaml_samples/kiri_commits.kibot.yaml
+++ b/tests/yaml_samples/kiri_commits.kibot.yaml
@@ -1,0 +1,15 @@
+kibot:
+  version: 1
+
+outputs:
+  - name: 'kiri'
+    comment: "Test for KiRi explicit commits"
+    type: kiri
+    layers: ['F.Cu', 'In1.Cu', 'F.SilkS']
+    options:
+      commits:
+        - v1
+        - HEAD
+      labels:
+        - 'Release v1'
+        - 'Release v2'


### PR DESCRIPTION
### Summary
This PR extends the KiRi output with explicit revision lists for release comparisons, and adds control over whether uncommitted local changes appear in the commit list.

### Motivation
KiRi’s default mode uses revision + max_commits to collect commits from git log. That works for “recent changes” views, but not for release-to-release comparisons where you want exactly two (or more) tagged board versions, in a specific order, with readable labels.

We also need a way to omit _local_ from CI-generated KiRi pages when KiBot temporarily dirties the working tree during the run.

### Output example
[One PCB I started working on](https://ucube-left-card-2831dd.gitlab.io/KiRI/Releases/index.html)