### PR TITLE
[Panelize][Added] Rail widener for pick-and-place sensor detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Panelize:
+  - `framing.widenercorners`/`widenerwidth`/`widenerlength` to add a rail
+    widener: a solid patch of extra rail material at chosen outer panel
+    corners, to give pick-and-place photoelectric sensors a bigger flat
+    target without growing the panel's outer outline
+
 ## [1.9.1] - 2026-07-28
 ### Added
 - Support for Python 3.14 (#930)

--- a/docs/source/configuration/outputs/PanelizeFraming.rst
+++ b/docs/source/configuration/outputs/PanelizeFraming.rst
@@ -103,6 +103,31 @@ PanelizeFraming parameters
 
 -  ``vspace`` :index:`: <pair: output - panelize - options - configs - framing; vspace>` [:ref:`number <number>` | :ref:`string <string>`] (default: ``2``) Specify the vertical space between PCB and the frame/rail.
 
+.. _PanelizeFraming_widenercorners:
+
+-  ``widenercorners`` :index:`: <pair: output - panelize - options - configs - framing; widenercorners>` [:ref:`string <string>` | :ref:`list(string) <list(string)>`] (default: ``''``) [:ref:`comma separated <comma_sep>`] [tl,tr,bl,br] List of rail/frame outer corners where a rail widener
+   patch is added. A widener is a solid patch of extra rail material used to give pick-and-place
+   photoelectric sensors a bigger flat target. It never grows the panel's outer outline and never overlaps
+   an actual board: the patch is clipped against the board outline(s) if it would otherwise reach that far. |br|
+   Only valid for `type` *railstb*, *railslr*, *frame* and *tightframe*.
+
+
+.. _PanelizeFraming_widenergap:
+
+-  ``widenergap`` :index:`: <pair: output - panelize - options - configs - framing; widenergap>` [:ref:`number <number>` | :ref:`string <string>`] (default: ``0``) Minimum gap kept between the rail widener patch and the board(s). When 0 (the default)
+   the frame's own `hspace`/`vspace` (whichever applies to the widener's growth direction) is used instead. |br|
+   Automatically increased by `tabs.fillet` internally, to counteract KiKit's own reverse-tab-fillet pass
+   which would otherwise round the patch into the board and eat into this gap.
+
+.. _PanelizeFraming_widenerlength:
+
+-  ``widenerlength`` :index:`: <pair: output - panelize - options - configs - framing; widenerlength>` [:ref:`number <number>` | :ref:`string <string>`] (default: ``0``) Length of the rail widener patch along the rail edge.
+
+.. _PanelizeFraming_widenerwidth:
+
+-  ``widenerwidth`` :index:`: <pair: output - panelize - options - configs - framing; widenerwidth>` [:ref:`number <number>` | :ref:`string <string>`] (default: ``0``) Depth of the rail widener patch, i.e. how far it reaches from the panel's outer edge
+   towards the board. Can exceed the rail/frame `width`; it's only clipped if it would overlap a board.
+
 .. _PanelizeFraming_width:
 
 -  ``width`` :index:`: <pair: output - panelize - options - configs - framing; width>` [:ref:`number <number>` | :ref:`string <string>`] (default: ``5``) Specify with of the rails or frame.

--- a/kibot/out_panelize.py
+++ b/kibot/out_panelize.py
@@ -335,6 +335,22 @@ class PanelizeFraming(PanelOptionsWithPlugin):
             """ [number|string=2] Width of the milled slot for *tightframe* """
             self.slot_width = None
             """ {slotwidth} """
+            self.widenercorners = Optionable
+            """ [string|list(string)=''] {comma_sep} [tl,tr,bl,br] List of rail/frame outer corners where a rail widener
+                patch is added. A widener is a solid patch of extra rail material used to give pick-and-place
+                photoelectric sensors a bigger flat target. It never grows the panel's outer outline and never overlaps
+                an actual board: the patch is clipped against the board outline(s) if it would otherwise reach that far.
+                Only valid for `type` *railstb*, *railslr*, *frame* and *tightframe* """
+            self.widenerwidth = 0
+            """ [number|string=0] Depth of the rail widener patch, i.e. how far it reaches from the panel's outer edge
+                towards the board. Can exceed the rail/frame `width`; it's only clipped if it would overlap a board """
+            self.widenerlength = 0
+            """ [number|string=0] Length of the rail widener patch along the rail edge """
+            self.widenergap = 0
+            """ [number|string=0] Minimum gap kept between the rail widener patch and the board(s). When 0 (the default)
+                the frame's own `hspace`/`vspace` (whichever applies to the widener's growth direction) is used instead.
+                Automatically increased by `tabs.fillet` internally, to counteract KiKit's own reverse-tab-fillet pass
+                which would otherwise round the patch into the board and eat into this gap """
         super().__init__()
 
     def config(self, parent):
@@ -343,6 +359,20 @@ class PanelizeFraming(PanelOptionsWithPlugin):
             self.hspace = self.vspace = self.space
         self.add_units(('hspace', 'vspace', 'space', 'width', 'fillet', 'chamfer', 'mintotalwidth', 'mintotalheight',
                         'slotwidth', 'chamferwidth', 'chamferheight'))
+        if len(self.widenercorners):
+            if self.type not in ('railstb', 'railslr', 'frame', 'tightframe'):
+                raise KiPlotConfigurationError('`widenercorners` needs a `type` of railstb, railslr, frame or '
+                                                f'tightframe, not `{self.type}`')
+            self.add_units(('widenerwidth', 'widenerlength', 'widenergap'), convert=True)
+            self.add_units(('hspace', 'vspace'), convert=True)
+            gap = self._widenergap if self.get_user_defined('widenergap') else \
+                (self._vspace if self.type in ('railstb', 'frame', 'tightframe') else self._hspace)
+            self.arg = json.dumps({'type': self.type, 'corners': self.widenercorners, 'width': self._widenerwidth,
+                                    'length': self._widenerlength, 'gap': gap})
+            self.code = 'kibot.panelize_plugins.rail_widener.RailWidenerFramingPlugin'
+            self.type = 'plugin'
+            for k in ('type', 'code', 'arg'):
+                self.set_user_defined(k)
 
 
 class PanelizeTooling(PanelOptionsWithPlugin):

--- a/kibot/panelize_plugins/rail_widener.py
+++ b/kibot/panelize_plugins/rail_widener.py
@@ -1,0 +1,125 @@
+"""
+Rail widener KiKit FramingPlugin.
+
+Builds the normal KiKit rail/frame (whichever `type` the user actually asked
+for) and then unions in a solid rectangular patch at one or more outer panel
+corners. The patch is meant to give pick-and-place photoelectric sensors a
+bigger flat target than the configured rail width would otherwise provide,
+without growing the panel's outer outline and without ever overlapping the
+actual board(s):
+
+- `width` (depth, perpendicular to the nearest rail edge) and `length`
+  (extent along the rail edge) grow the patch as far as requested, towards
+  the board. The backstop is the board outline itself, expanded by `gap`:
+  whatever part of the patch would come closer than `gap` to a board gets
+  clipped away (geometric subtraction), so it can never cut into, touch or
+  grow past the board regardless of rail `width`.
+
+  KiKit runs its own reverse-tab-fillet pass right after framing
+  (`buildTabFillets`, driven by `tabs.fillet`) that rounds the transition
+  between *any* new frame material - including this patch - and the board,
+  which would otherwise silently eat into (or fully close) our gap. We
+  compensate by adding `tabs.fillet` to the clip distance, so the gap that
+  survives after KiKit's own pass matches what was actually requested.
+
+  The patch also introduces one new concave ("step") corner where it returns
+  to the normal rail width - unlike the panel's own outer corners this isn't
+  touched by `framing.fillet`, yet it needs the same treatment: a sharp
+  concave corner isn't actually millable with a round tool, same reason the
+  rest of the rail is filleted. We add an exact tangent-arc patch (radius =
+  `framing.fillet`) at that one point only - computed directly from the
+  known corner/step geometry, not a broad buffer operation - so nothing else
+  (the gap to the board, the panel's true outer corner, pre-existing tab
+  notches) can be affected.
+
+Driven by KiBot's `panelize.framing.widenercorners/widenerwidth/widenerlength`
+options (see PanelizeFraming.config() in kibot/out_panelize.py), which set
+`framing.type: plugin` and point `code`/`arg` at this class.
+"""
+import json
+from shapely.geometry import box, Point
+from shapely.ops import unary_union
+from kikit.plugin import FramingPlugin
+from kikit.panelize_ui_impl import buildFraming as kikit_build_framing
+
+# Index into panel.panelCorners() -> [topLeft, topRight, bottomLeft, bottomRight]
+_CORNER_INDEX = {'tl': 0, 'tr': 1, 'bl': 2, 'br': 3}
+# Direction the patch grows from the corner point, towards the panel interior
+_CORNER_SIGN = {'tl': (1, 1), 'tr': (-1, 1), 'bl': (1, -1), 'br': (-1, -1)}
+# Which axis is the rail's thin (thickness) direction near each corner, for a given base type
+_DEPTH_AXIS = {'railstb': 'y', 'railslr': 'x', 'frame': 'y', 'tightframe': 'y'}
+
+
+class RailWidenerFramingPlugin(FramingPlugin):
+    def __init__(self, preset, userArg):
+        super().__init__(preset, userArg)
+        self.arg = json.loads(userArg)
+
+    def buildDummyFramingSubstrates(self, substrates):
+        # The widener only adds material at the outer corners, it doesn't
+        # affect where tabs/partition lines should be computed
+        return substrates
+
+    def buildFraming(self, panel):
+        framingPreset = self.preset['framing']
+        base_type = self.arg['type']
+        if base_type not in ('railstb', 'railslr', 'frame', 'tightframe'):
+            raise ValueError(f'Rail widener: unsupported base framing type `{base_type}`')
+
+        # Delegate to KiKit's own dispatcher (with `type` restored to the real
+        # base type) so we track whatever KiKit version is installed instead
+        # of duplicating its per-type builder call signatures here
+        inner_preset = dict(self.preset)
+        inner_preset['framing'] = dict(framingPreset)
+        inner_preset['framing']['type'] = base_type
+        cuts = list(kikit_build_framing(inner_preset, panel))
+
+        depth = self.arg['width']
+        length = self.arg['length']
+        # KiKit's own buildTabFillets() runs after buildFraming() and rounds
+        # the join between any new frame material and the board using this
+        # radius, which would otherwise eat into (or fully swallow) our gap
+        tabs_fillet = self.preset.get('tabs', {}).get('fillet', 0) or 0
+        gap = self.arg['gap'] + tabs_fillet
+        boards = unary_union([s.substrates for s in panel.substrates]) if panel.substrates else None
+        if boards is not None and gap > 0:
+            boards = boards.buffer(gap)
+
+        fillet = framingPreset['fillet']
+        rail_width = framingPreset['width']
+        minx, miny, maxx, maxy = panel.panelBBox()
+        panel_w, panel_h = maxx - minx, maxy - miny
+        corners = panel.panelCorners()
+        for name in self.arg['corners']:
+            corner = corners[_CORNER_INDEX[name]]
+            sx, sy = _CORNER_SIGN[name]
+            axis_y = _DEPTH_AXIS[base_type] == 'y'
+            if axis_y:
+                dx = min(length, panel_w / 2)
+                dy = depth
+            else:
+                dx = depth
+                dy = min(length, panel_h / 2)
+            x0, x1 = sorted((corner.x, corner.x + sx * dx))
+            y0, y1 = sorted((corner.y, corner.y + sy * dy))
+            patch = box(x0, y0, x1, y1)
+            if boards is not None:
+                # Never let the patch come closer than `gap` to an actual
+                # board, no matter how deep it was requested to grow
+                patch = patch.difference(boards)
+            panel.appendSubstrate(patch)
+
+            # Exact tangent-arc fillet at the single concave step point, only
+            # when there actually is a step (patch deeper/longer than the
+            # plain rail) and it doesn't reach all the way to the next corner
+            if fillet > 0 and depth > rail_width and (dx if axis_y else dy) < (panel_w / 2 if axis_y else panel_h / 2):
+                if axis_y:
+                    px, py = corner.x + sx * dx, corner.y + sy * rail_width
+                else:
+                    px, py = corner.x + sx * rail_width, corner.y + sy * dy
+                cx, cy = px + sx * fillet, py + sy * fillet
+                square = box(min(px, cx), min(py, cy), max(px, cx), max(py, cy))
+                fillet_patch = square.difference(Point(cx, cy).buffer(fillet, quad_segs=32))
+                panel.appendSubstrate(fillet_patch)
+
+        return cuts

--- a/kibot/resources/config_templates/PanelDemo_4x4.kibot.yaml
+++ b/kibot/resources/config_templates/PanelDemo_4x4.kibot.yaml
@@ -38,6 +38,11 @@ outputs:
             type: railstb
             width: 5
             space: 3
+            # Give the top-left and top-right corners a bigger flat area so
+            # pick-and-place photoelectric sensors can reliably detect the rail
+            widenercorners: [tl, tr]
+            widenerwidth: 5
+            widenerlength: 15
           copperfill:
             type: hatched
             clearance: 2


### PR DESCRIPTION
Closes #953

## Summary
Adds a "rail widener" to the `panelize` output: a solid patch of extra rail/frame material at chosen outer panel corners (`tl`/`tr`/`bl`/`br`), so pick-and-place photoelectric sensors get a bigger flat target without growing the panel's outer outline or ever overlapping a board.

- New `framing.widenercorners`/`widenerwidth`/`widenerlength`/`widenergap` options, valid for `framing.type` *railstb*/*railslr*/*frame*/*tightframe*.
- Implemented as a KiKit `FramingPlugin` (`kibot/panelize_plugins/rail_widener.py`) that delegates to KiKit's own framing builder for the requested base `type`, then unions in the corner patch(es).
- The patch is clipped against the board outline(s) (expanded by `widenergap`, defaulting to the frame's `hspace`/`vspace`) so it can never touch/overlap a board, with an extra allowance for KiKit's own reverse-tab-fillet pass so the gap that survives matches what was requested.
- The new concave "step" corner where the patch returns to the normal rail width gets an exact tangent-arc fillet (radius = `framing.fillet`), computed directly from the corner/step geometry so it only affects that one point.
- Updated `PanelDemo_4x4.kibot.yaml` to demonstrate widening the top corners.
- Regenerated the `PanelizeFraming` docs for the new options.

## Test plan
- [x] Ran the demo config (4x4 panel, `railstb` framing) through `kibot` and inspected the generated panel/preview: widened patches appear at the requested corners, never overlap the boards, and don't grow the panel outline.
- [x] Verified with `widenercorners` on all four corners at once, and with a widener `width`/`length` deep enough that it would otherwise overlap a board, confirming the clip.
- [x] Opened the generated panel in pcbnew to visually confirm the patches and the step fillet.
- [ ] No automated regression test added yet under `tests/test_plot/` — happy to add one if you can point me at the preferred board sample/pattern for panelize tests (I noticed `tests/board_samples/*/light_control.kicad_pcb` is used for other panelize tests).
